### PR TITLE
fix for contextual filter + exposed block form

### DIFF
--- a/web/modules/custom/asu_search/asu_search.module
+++ b/web/modules/custom/asu_search/asu_search.module
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Implements hook_form_alter().
+ * @param $form
+ * @param FormStateInterface $form_state
+ * @param $form_id
+ */
+function asu_search_form_views_exposed_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id){
+  if ($form['#id'] == 'views-exposed-form-solr-search-content-page-2') {
+    $current_path = \Drupal::service('path.current')->getPath();
+    $col_id = preg_match('/\/([^\/]+)\/?$/', $current_path);;
+    $new_search_path = preg_replace('/all/', $col_id, $form['#action']);
+    $form['#action'] = $new_search_path;
+  }
+}


### PR DESCRIPTION
hook fix for passing the collection node id to the search page for collections: based on https://www.drupal.org/project/drupal/issues/2821962

this implements a hook_form_alter and checks for the specific ID of the search view page 2, then it grabs the id from the url - as the last part of the url before the ? - i tried to keep that general in case we end up implementing URL aliases like `/collection/id` then it replaces the "all" part in the form action with that collection id. 

to test, pull down this PR and clear cache and try searching on a collection