### PR TITLE
ok now, ready to merge - any faceting in search removes "Matching Collections"

### DIFF
--- a/web/modules/custom/asu_search/asu_search.module
+++ b/web/modules/custom/asu_search/asu_search.module
@@ -34,3 +34,25 @@ function asu_search_preprocess_node(&$variables) {
     $variables['is_published'] = $asu_utils->isNodePublished($variables['node']);
   }
 }
+
+/**
+ * To potentially suppress the "Matching Collections" block for any /search
+ * that has had a facet filter applied to it.
+ */
+function asu_search_preprocess_views_view(&$variables) {
+  if ($variables['id'] == "solr_search_content") {
+    // inspect the query from the URL and if there are any facets, suppress
+    // the inclusion of the collections block at the top of the /search page.
+    $facet_filters = \Drupal::request()->query->get('f');
+    if (is_array($facet_filters) && count($facet_filters) > 0) {
+      // Since there are multiple header elements, check to be sure that the
+      // "view" is in the header... and only get rid of the header element that
+      // matches for a theme name of "view_view__solr_search_content__block_1".
+      if (
+        array_key_exists('view', $variables['header']) && !(array_search('views_view__solr_search_content__block_1', $variables['header']['view']['#theme']) === FALSE)
+      ) {
+        unset($variables['header']['view']);
+      }
+    }
+  }
+}

--- a/web/themes/custom/asulib_barrio/asulib_barrio.theme
+++ b/web/themes/custom/asulib_barrio/asulib_barrio.theme
@@ -100,3 +100,18 @@ function asulib_barrio_theme_suggestions_field_alter(&$suggestions, $variables) 
       $variables['element']['#bundle'] . '__' .
       $variables['element']['#view_mode'];
 }
+
+/**
+ * To potentially suppress the "Matching Collections" block for any /search
+ * that has had a facet filter applied to it.
+ */
+function asulib_barrio_preprocess_views_view(&$variables) {
+  if ($variables['id'] == "solr_search_content") {
+    // inspect the query from the URL and if there are any facets, suppress
+    // the inclusion of the collections block at the top of the /search page.
+    $facet_filters = \Drupal::request()->query->get('f');
+    if (is_array($facet_filters) && count($facet_filters) > 0) {
+      $variables['header'] = '';
+    }
+  }
+}

--- a/web/themes/custom/asulib_barrio/asulib_barrio.theme
+++ b/web/themes/custom/asulib_barrio/asulib_barrio.theme
@@ -100,24 +100,3 @@ function asulib_barrio_theme_suggestions_field_alter(&$suggestions, $variables) 
       $variables['element']['#bundle'] . '__' .
       $variables['element']['#view_mode'];
 }
-
-/**
- * To potentially suppress the "Matching Collections" block for any /search
- * that has had a facet filter applied to it.
- */
-function asulib_barrio_preprocess_views_view(&$variables) {
-  if ($variables['id'] == "solr_search_content") {
-    // inspect the query from the URL and if there are any facets, suppress
-    // the inclusion of the collections block at the top of the /search page.
-    $facet_filters = \Drupal::request()->query->get('f');
-    if (is_array($facet_filters) && count($facet_filters) > 0) {
-      // Since there are multiple header elements, check to be sure that the
-      // "view" is in the header... and only get rid of the header element that
-      // matches for a theme name of "view_view__solr_search_content__block_1".
-      if (array_key_exists('view', $variables['header']) &&
-        !(array_search('view_view__solr_search_content__block_1', $variables['header']['view']['#theme']) === FALSE) ) {
-        unset($variables['header']['view']);
-      }
-    }
-  }
-}

--- a/web/themes/custom/asulib_barrio/asulib_barrio.theme
+++ b/web/themes/custom/asulib_barrio/asulib_barrio.theme
@@ -111,7 +111,13 @@ function asulib_barrio_preprocess_views_view(&$variables) {
     // the inclusion of the collections block at the top of the /search page.
     $facet_filters = \Drupal::request()->query->get('f');
     if (is_array($facet_filters) && count($facet_filters) > 0) {
-      $variables['header'] = '';
+      // Since there are multiple header elements, check to be sure that the
+      // "view" is in the header... and only get rid of the header element that
+      // matches for a theme name of "view_view__solr_search_content__block_1".
+      if (array_key_exists('view', $variables['header']) &&
+        !(array_search('view_view__solr_search_content__block_1', $variables['header']['view']['#theme']) === FALSE) ) {
+        unset($variables['header']['view']);
+      }
     }
   }
 }


### PR DESCRIPTION
tiny bit of logic added to `asulib_barrio_preprocess_views_view` in order to suppress the Matching Collections block if there are any facets / filters applied to the /search for #192