### PR TITLE
Hotfix ready to review & merge (followed by deploy on staging sites) 

### DIFF
--- a/web/modules/custom/asu_collection_extras/asu_collection_extras.module
+++ b/web/modules/custom/asu_collection_extras/asu_collection_extras.module
@@ -103,10 +103,20 @@ function asu_collection_extras_solr_get_collection_children($collection_node) {
  *   The collection node id() value.
  */
 function asu_collection_extras_doCollectionSummary($collection_nid) {
+  $connection = \Drupal::service('database');
+  if (!$connection->schema()->tableExists('asu_collection_extras_collection_usage')) {
+    \Drupal::logger('asu_collection_extras')->warning('asu_collection_extras_collection_usage table does not exist. Re-install asu_collection_extras module or run SQL:
+' . "CREATE TABLE `asu_collection_extras_collection_usage` (
+  `nid` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'The collection \"node\".nid this record affects.',
+  `views` int(11) NOT NULL DEFAULT '0' COMMENT 'View total for all objects in the collection.',
+  `downloads` int(11) NOT NULL DEFAULT '0' COMMENT 'Download total for all objects in the collection.',
+  PRIMARY KEY (`nid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;");
+    return;
+  }
   $original_file_tid = key(\Drupal::entityTypeManager()
     ->getStorage('taxonomy_term')
     ->loadByProperties(['name' => "Original File"]));
-  // echo 'Calculating summary data for collection node id() = ' . $collection_nid;
   $children = asu_collection_extras_solr_get_collection_children($collection_nid);
   $collection_views = $collection_downloads = 0;
   foreach ($children as $child_nid => $child_arr) {
@@ -121,10 +131,7 @@ function asu_collection_extras_doCollectionSummary($collection_nid) {
       $collection_downloads +=\Drupal::service('islandora_matomo.default')->getDownloadsForFile($fid);
     }
   }
-  // echo print_r($children, TRUE);
-  $views = random_int(0, 950);
-  $downloads = random_int(0, 250);
-  $connection = \Drupal::service('database');
+
   $connection
     ->delete('asu_collection_extras_collection_usage')
     ->condition('nid', $collection_nid)

--- a/web/modules/custom/asu_collection_extras/src/Plugin/Block/AboutThisCollectionBlock.php
+++ b/web/modules/custom/asu_collection_extras/src/Plugin/Block/AboutThisCollectionBlock.php
@@ -158,7 +158,8 @@ class AboutThisCollectionBlock extends BlockBase implements ContainerFactoryPlug
     // Run a solr query first to get ALL the items under the collection using
     // the ancestors field.
     $children = asu_collection_extras_solr_get_collection_children($collection_node);
-    \Drupal::logger('asu_collection_extras')->info('<pre><code>' . print_r($children, TRUE) . '</code></pre>');
+    \Drupal::logger('asu_collection_extras')->info('Collection ' . $collection_node->id() . 
+      ' children:<pre><code>' . print_r($children, TRUE) . '</code></pre>');
     $items = $max_timestamp = 0;
     $islandora_models = $stat_box_row1 = [];
 
@@ -231,12 +232,24 @@ class AboutThisCollectionBlock extends BlockBase implements ContainerFactoryPlug
    */
   private function getCollectionViews($collection_node) {
     $collection_node_id = (is_object($collection_node) ? $collection_node->id() : $collection_node);
+    if (!$this->connection->schema()->tableExists('asu_collection_extras_collection_usage')) {
+      \Drupal::logger('asu_collection_extras')->warning('asu_collection_extras_collection_usage table does not exist. Re-install asu_collection_extras module or run SQL:' . 
+      "<code>CREATE TABLE `asu_collection_extras_collection_usage` (
+    `nid` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'The collection \"node\".nid this record affects.',
+    `views` int(11) NOT NULL DEFAULT '0' COMMENT 'View total for all objects in the collection.',
+    `downloads` int(11) NOT NULL DEFAULT '0' COMMENT 'Download total for all objects in the collection.',
+    PRIMARY KEY (`nid`)
+  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4</code>");
+      return 0;
+    }
     $collection_views = $this->connection
       ->query('SELECT views FROM asu_collection_extras_collection_usage WHERE nid = ' . $collection_node_id)
       ->fetchAll();
+    $v = 0;
     foreach ($collection_views as $c_obj) {
-      return $c_obj->views;
+      $v += $c_obj->views;
     }
+    return $v;
   }
 
   /**


### PR DESCRIPTION
The code now will check if the asu_collection_extras_collection_usage table exists before accessing it - if it does not exist, there will be a logger message that includes the SQL to create the table - also returns a 0 in cases where there is not a record for the given collection but the table does exist for #283. This should merge without an issue. At least this prevents the page from displaying "**The website encountered an unexpected error. Please try again later.**".

A separate drush command could be provided to create the table, or there could be an update hook to make the table as well.

To test, install this code and clear the cache.
1. knowing that the table does not exist, view any collection overview page and see that views has a 0. the page should not throw an error -- and there will be a notice in the watchdog on needing to create that table.
2. if the table does exist already and you need to see functionality, go into mysql and drop the asu_collection_extras_collection_usage table and perform step 1. above.
