### PR TITLE
Ready to merge - this is prerequisite for "Import/Update MODS" #13

### DIFF
--- a/config/sync/core.entity_form_display.taxonomy_term.titles.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.titles.default.yml
@@ -1,0 +1,60 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.titles.field_authority_link
+    - taxonomy.vocabulary.titles
+  module:
+    - controlled_access_terms
+    - path
+    - text
+id: taxonomy_term.titles.default
+targetEntityType: taxonomy_term
+bundle: titles
+mode: default
+content:
+  description:
+    type: text_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_authority_link:
+    weight: 101
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: authority_link_default
+    region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 100
+    region: content
+    third_party_settings: {  }
+hidden: {  }

--- a/config/sync/core.entity_view_display.taxonomy_term.titles.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.titles.default.yml
@@ -1,0 +1,36 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.titles.field_authority_link
+    - taxonomy.vocabulary.titles
+  module:
+    - controlled_access_terms
+    - text
+id: taxonomy_term.titles.default
+targetEntityType: taxonomy_term
+bundle: titles
+mode: default
+content:
+  description:
+    label: hidden
+    type: text_default
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_authority_link:
+    weight: 1
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: _blank
+    third_party_settings: {  }
+    type: authority_formatter_default
+    region: content
+hidden:
+  langcode: true
+  search_api_excerpt: true

--- a/config/sync/field.field.taxonomy_term.titles.field_authority_link.yml
+++ b/config/sync/field.field.taxonomy_term.titles.field_authority_link.yml
@@ -1,0 +1,30 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_authority_link
+    - taxonomy.vocabulary.titles
+  module:
+    - controlled_access_terms
+id: taxonomy_term.titles.field_authority_link
+field_name: field_authority_link
+entity_type: taxonomy_term
+bundle: titles
+label: 'Authority Sources'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  authority_sources:
+    din1430: 'Key Title nach DIN 1430 (Berlin: Beuth)'
+    din1502: 'Regeln für das Kürzen von Wörtern in Titeln und für das Kürzen der Titel von Veröffentlichungen: DIN 1502 (Berlin; Köln: Beuth)'
+    dnlm: 'National Library of Medicine Locatorplus (Bethesda, MD: National Library of Medicine)'
+    hlasja: 'HLAS journal abbreviations (Washington, DC: Library of Congress, Hispanic Division'
+    inisaljt: 'INIS: authority list for journal titles'
+    issnkey: 'Abbreviated key titles External Link'
+    other: Other
+  title: 1
+  link_type: 16
+field_type: authority_link


### PR DESCRIPTION
"added field_authority_link to the titles vocabulary" This is a single field configuration for the Titles vocabulary.  This branch will require importing three files in the configuration and then clearing the cache. After this, loading the Titles vocabulary's fields http://localhost:8000/admin/structure/taxonomy/manage/titles/overview/fields should show the new "Authority Sources" field on the terms for this Titles taxonomy vocabulary.

The configuration files that will need to be loaded:
- core.entity_form_display.taxonomy_term.titles.default.yml
- core.entity_view_display.taxonomy_term.titles.default.yml
- field.field.taxonomy_term.titles.field_authority_link.yml