### PR TITLE
new "Add media" button for admin_toolbox - ready to merge

### DIFF
--- a/web/modules/custom/asu_admin_toolbox/src/Plugin/Block/AdminToolboxBlock.php
+++ b/web/modules/custom/asu_admin_toolbox/src/Plugin/Block/AdminToolboxBlock.php
@@ -197,6 +197,16 @@ class AdminToolboxBlock extends BlockBase implements ContainerFactoryPluginInter
         $output_links[] = render($link) . " &nbsp;" . render($link_glyph);
       }
     }
+    if (!($is_complex_object)) {
+      $url = Url::fromUri(
+            $this->requestStack->getCurrentRequest()->getSchemeAndHttpHost() .
+            '/node/' . $node->id() . '/media/add'
+        );
+      $link = Link::fromTextAndUrl($this->t('Add media'), $url);
+      $link = $link->toRenderable();
+      $link_glyph = Link::fromTextAndUrl($this->t('<i class="fas fa-plus-circle"></i>'), $url)->toRenderable();
+      $output_links[] = render($link) . " &nbsp;" . render($link_glyph);
+    }
     return [
       '#markup' => (count($output_links) > 0) ?
       "<div class='pseudo_block'><h2>Admin toolbox</h2><nav><ul><li>" . implode("<hr>", $output_links) . "</li></ul></nav></div>" :


### PR DESCRIPTION
Very simple enhancement of admin toolbox ... adds a button/link to the admin toolbox to add media if the item is not a complex object model. This is the last link in the box, but in the case of complex objects the "Add item" (child asu_repository_item node) would be the first link. I think it didn't look right when it was before the Edit link for a "Digital Document" model item at least.