### PR TITLE
do not show add media for collections for 321

### DIFF
--- a/web/modules/custom/asu_admin_toolbox/src/Plugin/Block/AdminToolboxBlock.php
+++ b/web/modules/custom/asu_admin_toolbox/src/Plugin/Block/AdminToolboxBlock.php
@@ -197,7 +197,7 @@ class AdminToolboxBlock extends BlockBase implements ContainerFactoryPluginInter
         $output_links[] = render($link) . " &nbsp;" . render($link_glyph);
       }
     }
-    if (!($is_complex_object)) {
+    if (!($is_complex_object) && (!$is_collection)) {
       $url = Url::fromUri(
             $this->requestStack->getCurrentRequest()->getSchemeAndHttpHost() .
             '/node/' . $node->id() . '/media/add'


### PR DESCRIPTION
minor adjustment to not show the "Add media" link for collection objects.

NOTE: this was not tested in my local VM due to a temporary issue with gemini being down in this box.