### PR TITLE
Ready to merge Facet style word-wrap

### DIFF
--- a/web/themes/custom/asulib_barrio/scss/components/facets.scss
+++ b/web/themes/custom/asulib_barrio/scss/components/facets.scss
@@ -77,3 +77,12 @@ div#block-searchfilterblock {
 #block-facetsummary ul > li:first-child:before {
    content: "";
 }
+
+.facet-item a {
+   display: table;
+   width: 100%;
+}
+
+.facet-item a .facet-item__value, .facet-item a .facet-item__count {
+   display: table-cell;
+}


### PR DESCRIPTION
Adjusted so that each facet is rendered as a table so that the left span and right span can top-align for #206.

Check out the branch and review a search page that contains at least one facet that has multiple lines with the facet count previously being displayed at the bottom of each facet text.

See that the facet count is displayed top-aligned with the first line of the facet text.