### PR TITLE
fix final two warning notifications in watchdog

### DIFF
--- a/web/modules/custom/asu_mods/src/Encoder/ModsEncoder.php
+++ b/web/modules/custom/asu_mods/src/Encoder/ModsEncoder.php
@@ -197,7 +197,7 @@ class ModsEncoder extends XmlEncoder {
       elseif (is_array($val) && count($val) == 1) {
         $val = $val[0];
       }
-      if (isset($sub_part)) {
+      if (!empty($sub_part)) {
         $return_vals[] = $val[$sub_part];
       }
       else {


### PR DESCRIPTION
The only change is to check $sub_part is not empty rather than isset. This should get rid of the final two warnings that occur in the watchdog.

This branch has just been merged back with latest develop code, so it should only be one commit ahead (ez merge).