### PR TITLE
added modified field to the two tables for #359

### DIFF
--- a/web/modules/custom/asu_collection_extras/asu_collection_extras.install
+++ b/web/modules/custom/asu_collection_extras/asu_collection_extras.install
@@ -1,5 +1,7 @@
 <?php
 
+use Drupal\Core\Database\Database;
+
 /**
  * @file
  * Update hooks for the ASU Collection Extras module.
@@ -29,6 +31,12 @@ function asu_collection_extras_schema() {
       ],
       'downloads' => [
         'description' => 'Download total for all objects in the collection.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ],
+      'modified' => [
+        'description' => 'Timestamp for when the record is updated',
         'type' => 'int',
         'not null' => TRUE,
         'default' => 0,
@@ -66,6 +74,12 @@ function asu_collection_extras_schema() {
         'not null' => TRUE,
         'default' => 0,
       ],
+      'modified' => [
+        'description' => 'Timestamp for when the record is updated',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ],
     ],
     'primary key' => ['collection_nid', 'nid'],
     'indexes' => [
@@ -78,4 +92,20 @@ function asu_collection_extras_schema() {
     ],
   ];
   return $schema;
+}
+
+/**
+ * Implements hook_update_8001() to add modified field.
+ */
+function asu_collection_extras_update_8001() {
+  // Add the modified field to the two tables.
+  $spec = [
+    'type' => 'int',
+    'description' => 'Timestamp for when the record is updated',
+    'not null' => TRUE,
+    'default' => 0,
+  ];
+  $schema = Database::getConnection()->schema();
+  $schema->addField('asu_collection_extras_item_downloads', 'modified', $spec);
+  $schema->addField('asu_collection_extras_collection_usage', 'modified', $spec);
 }

--- a/web/modules/custom/asu_collection_extras/asu_collection_extras.module
+++ b/web/modules/custom/asu_collection_extras/asu_collection_extras.module
@@ -120,6 +120,7 @@ function asu_collection_extras_doCollectionSummary($collection_nid) {
   `nid` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'The item \"node\".nid this record affects.',
   `views` int(11) NOT NULL DEFAULT '0' COMMENT 'View total for all objects in the collection.',
   `downloads` int(11) NOT NULL DEFAULT '0' COMMENT 'Download total for all objects in the collection.',
+  `modified` int(11) NOT NULL DEFAULT '0' COMMENT 'Timestamp for when the record is updated',
   PRIMARY KEY (`collection_nid`,`nid`),
   KEY `downloads` (`downloads`),
   KEY `collection_nid` (`collection_nid`)
@@ -150,10 +151,10 @@ function asu_collection_extras_doCollectionSummary($collection_nid) {
       $connection
         ->insert('asu_collection_extras_item_downloads')
         ->fields([
-          'collection_nid', 'nid', 'views', 'downloads'
+          'collection_nid', 'nid', 'views', 'downloads', 'modified'
         ])
         ->values([
-          $collection_nid, $child_nid, $item_views, $item_downloads
+          $collection_nid, $child_nid, $item_views, $item_downloads, time()
         ])
         ->execute();
     }
@@ -168,10 +169,10 @@ function asu_collection_extras_doCollectionSummary($collection_nid) {
   $connection
     ->insert('asu_collection_extras_collection_usage')
     ->fields([
-      'nid', 'views', 'downloads'
+      'nid', 'views', 'downloads', 'modified'
     ])
     ->values([
-      $collection_nid, $collection_views, $collection_downloads
+      $collection_nid, $collection_views, $collection_downloads, time()
     ])
     ->execute();
 }

--- a/web/modules/custom/asu_collection_extras/src/Plugin/Block/AboutThisCollectionBlock.php
+++ b/web/modules/custom/asu_collection_extras/src/Plugin/Block/AboutThisCollectionBlock.php
@@ -238,6 +238,7 @@ class AboutThisCollectionBlock extends BlockBase implements ContainerFactoryPlug
     `nid` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'The collection \"node\".nid this record affects.',
     `views` int(11) NOT NULL DEFAULT '0' COMMENT 'View total for all objects in the collection.',
     `downloads` int(11) NOT NULL DEFAULT '0' COMMENT 'Download total for all objects in the collection.',
+    `modified` int(11) NOT NULL DEFAULT '0' COMMENT 'Timestamp for when the record is updated'
     PRIMARY KEY (`nid`)
   ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4</code>");
       return 0;


### PR DESCRIPTION
After pulling the branch, you must run update.php in order to process the hook_update_8001() code.

This will add a timestamp integer value to both tables. It is not set up as an auto-update, but the code that inserts records will also set this field value.

After updating, you should be able to run the drush command that is called in CRON.
 `drush asu_cs`