### PR TITLE
ready to review and merge

### DIFF
--- a/web/modules/custom/asu_mods/src/Encoder/ModsEncoder.php
+++ b/web/modules/custom/asu_mods/src/Encoder/ModsEncoder.php
@@ -62,7 +62,7 @@ class ModsEncoder extends XmlEncoder {
       $field_name = $field_name_parts[0];
       $sub_part = $field_name_parts[1];
     }
-    $return_vals = [];
+    $return_vals = $vals = [];
 
     if ((!is_array($field_name) && str_contains($field_name, 'field_')) || (in_array($field_name, self::MACHINE_FIELDS))) {
       if ($data->hasField($field_name)) {
@@ -267,7 +267,20 @@ class ModsEncoder extends XmlEncoder {
         }
       }
     }
-    return $new_data;
+    return $this->fixData($new_data);
+  }
+
+  private function fixData($data) {
+    foreach ($data as $k => $v) {
+      if (is_array($v)) {
+        if (count($v) < 1) {
+          $data[$k] = '';
+        } else {
+          $data[$k] = $this->fixData($v);
+        }
+      }
+    }
+    return $data;
   }
 
   /**


### PR DESCRIPTION
This effectively only replaces any values in the $data that have a value of an empty array and replace that with an empty string value. All notifications should now be gone when viewing an item's MODS.

NOTE: the items that were exhibiting this issue were ones that had a field that linked to an entity that had a value missing... for example a collection but its `field_handle` was empty, or a linked agent but the field_authority_link URI was not set.

For example, the one that had issues before: https://keep.lib.asu.edu/items/276?_format=mods 
