### PR TITLE
adjusted search header, collection stats counts, and facets count displays to use thousands separators for #386

### DIFF
--- a/web/modules/custom/asu_collection_extras/src/Plugin/Block/AboutThisCollectionBlock.php
+++ b/web/modules/custom/asu_collection_extras/src/Plugin/Block/AboutThisCollectionBlock.php
@@ -191,12 +191,13 @@ class AboutThisCollectionBlock extends BlockBase implements ContainerFactoryPlug
     // Calculate the "Items" box link.
     $items_url = Url::fromUri($this->requestStack->getCurrentRequest()->getSchemeAndHttpHost() . '/collections/' .
        (($collection_node) ? $collection_node->id() : 0) . '/search/?search_api_fulltext=');
-    $stat_box_row1[] = $this->makeBox("<strong>" . $items . "</strong><br>items", $items_url);
-    $stat_box_row1[] = $this->makeBox("<strong>" . $files . "</strong><br>files");
+    $stat_box_row1[] = $this->makeBox("<strong>" . number_format($items) . "</strong><br>items", $items_url);
+    $stat_box_row1[] = $this->makeBox("<strong>" . number_format($files) . "</strong><br>files");
+    // Skip number_format - should never be more than a 1,000 models.
     $stat_box_row1[] = $this->makeBox("<strong>" . count($islandora_models) . "</strong><br>resource types");
-    $stat_box_row2[] = $this->makeBox("<strong>" . $collection_views_and_downloads['views'] .
+    $stat_box_row2[] = $this->makeBox("<strong>" . number_format($collection_views_and_downloads['views']) .
       "</strong><br>views");
-    $stat_box_row2[] = $this->makeBox("<strong>" . $collection_views_and_downloads['downloads'] .
+    $stat_box_row2[] = $this->makeBox("<strong>" . number_format($collection_views_and_downloads['downloads']) .
       "</strong><br>downloads");
     $stat_box_row2[] = $this->makeBox("<strong>" . (($collection_created) ? date('Y', $collection_created) : 'unknown') .
       "</strong><br>collection created");

--- a/web/modules/custom/asu_search/asu_search.module
+++ b/web/modules/custom/asu_search/asu_search.module
@@ -100,6 +100,15 @@ function asu_search_preprocess_node(&$variables) {
  */
 function asu_search_preprocess_views_view(&$variables) {
   if ($variables['id'] == "solr_search_content") {
+    $view = $variables['view'];
+    $search_displays = ['page_1', 'page_2', 'page_3'];
+    if (!(array_search($view->current_display, $search_displays) === FALSE)) {
+      // Get the query count and set a variable for output in a custom twig for
+      // this view's header.
+      $view->get_total_rows = TRUE;
+      $view->execute($view->current_display);
+      $variables['total_rows_formatted'] = number_format($view->total_rows);
+    } 
     // inspect the query from the URL and if there are any facets, suppress
     // the inclusion of the collections block at the top of the /search page.
     $facet_filters = \Drupal::request()->query->get('f');

--- a/web/themes/custom/asulib_barrio/templates/facets-result-item.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/facets-result-item.html.twig
@@ -24,5 +24,5 @@
 	</span>
 {% endif %}
 {% if show_count %}
-  <span class="facet-item__count badge badge-pill badge-light">{{ count }}</span>
+  <span class="facet-item__count badge badge-pill badge-light">{{ count|number_format(0, '.', ',') }}</span>
 {% endif %}

--- a/web/themes/custom/asulib_barrio/templates/views-view--solr-search-content--page-1.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/views-view--solr-search-content--page-1.html.twig
@@ -47,10 +47,18 @@
   {{ title_suffix }}
   {% if header %}
     <div class="view-header">
-      {{ header }}
+      {% if total_rows_formatted %}
+        <h2>Matching Items ({{ total_rows_formatted }})</h2>
+      {% else %}
+        {{ header }}
+      {% endif %}
     </div>
     {{ drupal_block('asu_facets_summary_block:facet_summary', wrapper=false) }}
   {% endif %}
+{% if total-rows-formatted %}
+  {{ total-rows-formatted }}
+{% endif %}
+  
   {% if exposed %}
     <div class="view-filters">
       {{ exposed }}
@@ -71,25 +79,4 @@
     </div>
   {% endif %}
 
-  {% if pager %}
-    {{ pager }}
-  {% endif %}
-  {% if attachment_after %}
-    <div class="attachment attachment-after">
-      {{ attachment_after }}
-    </div>
-  {% endif %}
-  {% if more %}
-    {{ more }}
-  {% endif %}
-  {% if footer %}
-    <div class="view-footer">
-      {{ footer }}
-    </div>
-  {% endif %}
-  {% if feed_icons %}
-    <div class="feed-icons">
-      {{ feed_icons }}
-    </div>
-  {% endif %}
 </div>


### PR DESCRIPTION
This pull request does not require any config changes. There are a couple twig and a preprocess_views_view hook enhancements.

Pull this branch, run `drush cr` and load several pages that will display the values with a thousands separator. Since it is likely that it will be hard to find an item that has more than 999 downloads, views - or collections with more than 999 files or items, it may be easier to temporarily hack the code to add a value to the existing values. This can be done in web/modules/custom/asu_collection_extras/src/Plugin/Block/AboutThisCollectionBlock.php by modifying the lines 194-200:
```
    $stat_box_row1[] = $this->makeBox("<strong>" . number_format(999+$items) . "</strong><br>items", $items_url);
    $stat_box_row1[] = $this->makeBox("<strong>" . number_format(999+$files) . "</strong><br>files");
    // Skip number_format - should never be more than a 1,000 models.
    $stat_box_row1[] = $this->makeBox("<strong>" . count($islandora_models) . "</strong><br>resource types");
    $stat_box_row2[] = $this->makeBox("<strong>" . number_format(999+$collection_views_and_downloads['views']) .
      "</strong><br>views");
    $stat_box_row2[] = $this->makeBox("<strong>" . number_format(999+$collection_views_and_downloads['downloads']) .
      "</strong><br>downloads");
```

It may also be helpful to hack the number of matching items on a search page. This can be done in web/modules/custom/asu_search/asu_search.module by modifying line 109:
```
      $variables['total_rows_formatted'] = number_format(999+$view->total_rows);
```

The facets results can be hacked to make 4 digit+ numbers by editing web/themes/custom/asulib_barrio/templates/facets-result-item.html.twig  at line 27:
```
  <span class="facet-item__count badge badge-pill badge-light">{{ (999+count)|number_format(0, '.', ',') }}</span>
```