### PR TITLE
Typed identifier link for DOI

### DIFF
--- a/web/themes/custom/asulib_barrio/asulib_barrio.theme
+++ b/web/themes/custom/asulib_barrio/asulib_barrio.theme
@@ -99,7 +99,6 @@ function asulib_barrio_preprocess_node(&$variables) {
  * Converts typed identifiers for DOI into links based on our use cases.
  */
 function asulib_barrio_preprocess_paragraph(&$variables) {
-  \Drupal::logger('asulib barrio')->info('paragraph->id() = ' . $variables['paragraph']->id());
   $paragraph = $variables['paragraph'];
   if ($paragraph->bundle() == 'typed_identifier' && $paragraph->hasField('field_identifier_type') &&
     !is_null($paragraph->get('field_identifier_type')->referencedEntities()[0]) &&
@@ -108,7 +107,6 @@ function asulib_barrio_preprocess_paragraph(&$variables) {
     // If the value has http:// or https:// then use that link value, else
     // create a link that is https://doi.
     preg_match_all('/^http(s?):\/\//m', $identifier_value, $matches, PREG_SET_ORDER, 0);
-    \Drupal::logger('asulib barrio')->info('$matches = ' . print_r($matches, true));
     if (count($matches) > 0) {
       // Value is a link already.
       $url = Url::fromUri($identifier_value);
@@ -118,8 +116,6 @@ function asulib_barrio_preprocess_paragraph(&$variables) {
       $url = Url::fromUri('https://doi.org/' . $identifier_value);
       $variables['DOI_link'] = Link::fromTextAndUrl($identifier_value, $url);
     }
- //    if (strstr($identifier_value, ))
-    \Drupal::logger('asulib barrio')->info('$identifier_value = ' . $identifier_value);
   }
 }
 

--- a/web/themes/custom/asulib_barrio/asulib_barrio.theme
+++ b/web/themes/custom/asulib_barrio/asulib_barrio.theme
@@ -1,6 +1,8 @@
 <?php
 
 use Drupal\Core\Template\Attribute;
+use Drupal\Core\Url;
+use Drupal\Core\Link;
 
 /**
  * @file
@@ -89,6 +91,35 @@ function asulib_barrio_preprocess_node(&$variables) {
     $url_parts = explode('/', $site_url, -1);
     $domain = $url_parts[2];
     $variables['oai_base_url'] = $site_url . 'oai/request?verb=GetRecord&metadataPrefix=oai_dc&identifier=oai:' . $domain . ':node-';
+  }
+}
+
+/**
+ * Implements hook_preprocess_paragraph()
+ * Converts typed identifiers for DOI into links based on our use cases.
+ */
+function asulib_barrio_preprocess_paragraph(&$variables) {
+  \Drupal::logger('asulib barrio')->info('paragraph->id() = ' . $variables['paragraph']->id());
+  $paragraph = $variables['paragraph'];
+  if ($paragraph->bundle() == 'typed_identifier' && $paragraph->hasField('field_identifier_type') &&
+    !is_null($paragraph->get('field_identifier_type')->referencedEntities()[0]) &&
+    $paragraph->get('field_identifier_type')->referencedEntities()[0]->label() == 'Digital object identifier') {
+    $identifier_value = $paragraph->get('field_identifier_value')->value;
+    // If the value has http:// or https:// then use that link value, else
+    // create a link that is https://doi.
+    preg_match_all('/^http(s?):\/\//m', $identifier_value, $matches, PREG_SET_ORDER, 0);
+    \Drupal::logger('asulib barrio')->info('$matches = ' . print_r($matches, true));
+    if (count($matches) > 0) {
+      // Value is a link already.
+      $url = Url::fromUri($identifier_value);
+      $variables['DOI_link'] = Link::fromTextAndUrl($identifier_value, $url);
+    }
+    else {
+      $url = Url::fromUri('https://doi.org/' . $identifier_value);
+      $variables['DOI_link'] = Link::fromTextAndUrl($identifier_value, $url);
+    }
+ //    if (strstr($identifier_value, ))
+    \Drupal::logger('asulib barrio')->info('$identifier_value = ' . $identifier_value);
   }
 }
 

--- a/web/themes/custom/asulib_barrio/templates/field/paragraph--typed-identifier.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/field/paragraph--typed-identifier.html.twig
@@ -1,0 +1,59 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a paragraph.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
+ *   - paragraph.id(): The paragraph ID.
+ *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
+ *   - paragraph.getOwnerId(): The user ID of the paragraph author.
+ *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
+ *   and methods for the paragraph object.
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+{%
+  set classes = [
+    'paragraph',
+    'paragraph--type--' ~ paragraph.bundle|clean_class,
+    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+    not paragraph.isPublished() ? 'paragraph--unpublished'
+  ]
+%}
+{% block paragraph %}
+  <div{{ attributes.addClass(classes) }}>
+    {% block content %}
+      {% if DOI_link %}
+        Digital object identifier: {{ DOI_link }}
+      {% else %}
+        {{ content }}
+      {% endif %}
+    {% endblock %}
+  </div>
+{% endblock paragraph %}


### PR DESCRIPTION
This is a very small change that formats the DOI link based on whether or not the Typed Identifer is "Digital Object Identifier" type and if that has a value that contains "http" or "https".

The change is entirely contained in the theme code and after pulling this branch, it only requires `drush cr` before it can be seen.

To test, navigate to an object that has a Digital Object Identifier value on one of the Typed Identifier fields it may have such as https://keep.lib.asu.edu/items/496. Also, confirm that identifiers that do not meet the conditions are not displayed differently than expected.