### PR TITLE
added link to members reorder for canUpdate users of complex objects …

### DIFF
--- a/web/modules/custom/asu_admin_toolbox/src/Plugin/Block/AdminToolboxBlock.php
+++ b/web/modules/custom/asu_admin_toolbox/src/Plugin/Block/AdminToolboxBlock.php
@@ -198,7 +198,17 @@ class AdminToolboxBlock extends BlockBase implements ContainerFactoryPluginInter
       $link = $link->toRenderable();
       $link_glyph = Link::fromTextAndUrl($this->t('<i class="fas fa-pencil-alt"></i>'), $url)->toRenderable();
       $output_links[] = render($link) . " &nbsp;" . render($link_glyph);
-
+      if ($canUpdate && $is_complex_object) {
+        // Reorder items
+        $url = Url::fromUri(
+              $this->requestStack->getCurrentRequest()->getSchemeAndHttpHost() .
+              '/node/' . $node->id() . '/members/reorder'
+          );
+        $link = Link::fromTextAndUrl($this->t('Reorder items'), $url);
+        $link = $link->toRenderable();
+        $link_glyph = Link::fromTextAndUrl($this->t('<i class="fas fa-arrows-alt-v"></i>'), $url)->toRenderable();
+        $output_links[] = render($link) . " &nbsp;" . render($link_glyph);
+      }
       if ($is_collection) {
         // Statistics link.
         $url = Url::fromUri($this->requestStack->getCurrentRequest()->getSchemeAndHttpHost() . '/collections/' . $node->id() . '/statistics');
@@ -212,6 +222,7 @@ class AdminToolboxBlock extends BlockBase implements ContainerFactoryPluginInter
         $output_links[] = "<div class='field--label-inline'><div class='field__label'>Model</div>: " . $node->get('field_model')->entity->getName() . "</div>";
       }
     }
+
     if (!($is_complex_object) && (!$is_collection)) {
       $url = Url::fromUri(
             $this->requestStack->getCurrentRequest()->getSchemeAndHttpHost() .


### PR DESCRIPTION
This change is completely in the AdminToolboxBlock.php code, so this merely requires pulling in the branch and then doing a `drush cr`.

To test, navigate to a complex object as a user who can change it and follow the "Reorder children" link that should appear in the Admin Toolbox. Also, test the same as a user who cannot change this object to ensure that the link does not appear for them.

This PR also fixes a change to permissions for the media/add link that was broken by commit https://github.com/asulibraries/islandora-repo/commit/b5be055b9 for #354. It had lost the $canUpdate check on that link's visibility.