### PR TITLE
Add "Reorder items" link to admin toolbox

### DIFF
--- a/web/modules/custom/asu_admin_toolbox/src/Plugin/Block/AdminToolboxBlock.php
+++ b/web/modules/custom/asu_admin_toolbox/src/Plugin/Block/AdminToolboxBlock.php
@@ -206,7 +206,7 @@ class AdminToolboxBlock extends BlockBase implements ContainerFactoryPluginInter
           );
         $link = Link::fromTextAndUrl($this->t('Reorder items'), $url);
         $link = $link->toRenderable();
-        $link_glyph = Link::fromTextAndUrl($this->t('<i class="fas fa-arrows-alt-v"></i>'), $url)->toRenderable();
+        $link_glyph = Link::fromTextAndUrl($this->t('<i class="fas fa-sort"></i>'), $url)->toRenderable();
         $output_links[] = render($link) . " &nbsp;" . render($link_glyph);
       }
       if ($is_collection) {


### PR DESCRIPTION
This change is entirely in the AdminTooboxBlock.php code so there is no config needed to import. Just change to this branch and clear the cache.

To test, navigate to any complex object parent object and use the "Reorder items" link in the toolbox. Also, ensure that this link does not display on any other items than asu_repository_item with the model "Complex object".