### PR TITLE
installed drupal/honeypot, set up config for contact and feedback forms for #244

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
         "drupal/geolocation": "^3.4",
         "drupal/google_analytics": "^3.1",
         "drupal/group": "^1.3",
+        "drupal/honeypot": "^2.0",
         "drupal/inline_entity_form": "^1.0@RC",
         "drupal/jquery_ui_slider": "^1.1",
         "drupal/jquery_ui_touch_punch": "^1.0",

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -87,6 +87,7 @@ module:
   hdl: 0
   help: 0
   history: 0
+  honeypot: 0
   image: 0
   inline_entity_form: 0
   islandora: 0

--- a/config/sync/honeypot.settings.yml
+++ b/config/sync/honeypot.settings.yml
@@ -1,0 +1,18 @@
+unprotected_forms:
+  - user_login_form
+  - search_form
+  - search_block_form
+  - views_exposed_form
+  - honeypot_settings_form
+protect_all_forms: false
+log: false
+element_name: url
+time_limit: 5
+expire: 300
+form_settings:
+  user_register_form: false
+  user_pass: false
+  feedback_contact_message_form: false
+  _contact_message_form: false
+_core:
+  default_config_hash: 9bVDfWSa_In6VzTXmy04jJ_3ZQobihKjO9isuuUCPaw

--- a/config/sync/webform.webform.contact.yml
+++ b/config/sync/webform.webform.contact.yml
@@ -4,6 +4,11 @@ dependencies:
   enforced:
     module:
       - webform
+  module:
+    - honeypot
+third_party_settings:
+  honeypot:
+    honeypot: true
 open: null
 close: null
 weight: 0

--- a/config/sync/webform.webform.feedback.yml
+++ b/config/sync/webform.webform.feedback.yml
@@ -1,6 +1,11 @@
 langcode: en
 status: open
-dependencies: {  }
+dependencies:
+  module:
+    - honeypot
+third_party_settings:
+  honeypot:
+    honeypot: true
 open: null
 close: null
 weight: 0


### PR DESCRIPTION
(I had to redo the changes because it seemed to be based off of the reorder_children_354 branch)

This change requires that the drupal/honeypot module is installed. The composer.json file does include this, so you may be able to run `composer install` -- otherwise, `composer require drupal/honeypot`.

The changes are all config-based, so the four files will need to be loaded. These are:
config/sync/core.extension.yml -- can skip this if you just run `drush pm-enable honeypot`.
config/sync/honeypot.settings.yml
config/sync/webform.webform.contact.yml
config/sync/webform.webform.contact.yml

After importing the above config and clearing the cache, the contact and feedback webforms should be protecting these two forms from unwanted submissions. Log out of the drupal site and then navigate to the contact form and the feedback form to make a submission.

NOTE: with my local install, I did not have SMTP configured to send email -- so the two webforms both were not able to send mail. I got "Unable to send email. Contact the site administrator if the problem persists."

NOTE: the option in honeypot settings to "log blocked form submissions" may really be desired as well - at least until some analysis of the rejections could be done.