### PR TITLE
Hide empty explore block - I think it meets the spec.

### DIFF
--- a/web/modules/custom/asu_item_extras/src/Plugin/Block/ExploreThisItemBlock.php
+++ b/web/modules/custom/asu_item_extras/src/Plugin/Block/ExploreThisItemBlock.php
@@ -9,6 +9,7 @@ use Drupal\Core\Link;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\Form\FormBuilderInterface;
+use Drupal\Core\Session\AccountProxy;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -23,6 +24,13 @@ use Symfony\Component\HttpFoundation\RequestStack;
  * )
  */
 class ExploreThisItemBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * Drupal\Core\Session\AccountProxy definition.
+   *
+   * @var \Drupal\Core\Session\AccountProxy
+   */
+  protected $currentUser;
 
   /**
    * The routeMatch definition.
@@ -66,6 +74,8 @@ class ExploreThisItemBlock extends BlockBase implements ContainerFactoryPluginIn
    *   The plugin_id for the formatter.
    * @param mixed $plugin_definition
    *   The plugin implementation definition.
+   * @param \Drupal\Core\Session\AccountProxy $current_user
+   *   The current user.
    * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
    *   The route match.
    * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
@@ -77,8 +87,9 @@ class ExploreThisItemBlock extends BlockBase implements ContainerFactoryPluginIn
    * @param mixed $islandoraUtils
    *   IslandoraUtils Utility class.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, RouteMatchInterface $route_match, RequestStack $request_stack, EntityTypeManager $entityTypeManager, FormBuilderInterface $formBuilder, $islandoraUtils) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, AccountProxy $current_user, RouteMatchInterface $route_match, RequestStack $request_stack, EntityTypeManager $entityTypeManager, FormBuilderInterface $formBuilder, $islandoraUtils) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->currentUser = $current_user;
     $this->routeMatch = $route_match;
     $this->requestStack = $request_stack;
     $this->entityTypeManager = $entityTypeManager;
@@ -94,6 +105,7 @@ class ExploreThisItemBlock extends BlockBase implements ContainerFactoryPluginIn
       $configuration,
       $plugin_id,
       $plugin_definition,
+      $container->get('current_user'),
       $container->get('current_route_match'),
       $container->get('request_stack'),
       $container->get('entity_type.manager'),
@@ -122,7 +134,7 @@ class ExploreThisItemBlock extends BlockBase implements ContainerFactoryPluginIn
 
     $output_links = [];
     $search_form = NULL;
-    if ($field_model == 'Image' && $this->canAccessItemMedia($nid)) {
+    if ($field_model == 'Image' && $this->canAccessItemMedia($node)) {
       $url = Url::fromUri($this->requestStack->getCurrentRequest()->getSchemeAndHttpHost() . '/items/' . $nid . '/view');
       $link = Link::fromTextAndUrl($this->t('View Image'), $url);
       // Get the node's service file information from the node - just use the
@@ -136,7 +148,7 @@ class ExploreThisItemBlock extends BlockBase implements ContainerFactoryPluginIn
       return $renderArray;
     }
     elseif ($field_model == 'Paged Content' || $field_model == 'Page' ||
-      ($field_model == 'Digital Document' && $this->canAccessItemMedia($nid))) {
+      ($field_model == 'Digital Document' && $this->canAccessItemMedia($node))) {
       // "Start reading" and "Show all pages" links as well as a search box.
       // get the node's openseadragon viewer url.
       $url = Url::fromUri($this->requestStack->getCurrentRequest()->getSchemeAndHttpHost() . '/items/' . $nid . '/view');
@@ -180,13 +192,15 @@ class ExploreThisItemBlock extends BlockBase implements ContainerFactoryPluginIn
     return Cache::mergeContexts(parent::getCacheContexts(), ['route']);
   }
 
-  private function canAccessItemMedia($nid) {
+  private function canAccessItemMedia($node) {
     // Get the media for "Original File" and check for any access restrictions
     // on it.
-    $origfile_term = $utils->getTermForUri('http://pcdm.org/use#OriginalFile');
-    $node_mids = $this->islandoraUtils->getMediaReferencingNodeAndTerm($node, $origfile_term);
+    $origfile_term = $this->islandoraUtils->getTermForUri('http://pcdm.org/use#OriginalFile');
+//    $node_mids = $this->islandoraUtils->getMediaReferencingNodeAndTerm($node, $origfile_term);
+    $origfile = $this->islandoraUtils->getMediaWithTerm($node, $origfile_term);
+    $origfile_access = (!is_null($origfile) && $origfile->access('view', $this->currentUser));
     // Dunno...
-    return TRUE;
+    return $origfile_access;
   }
 
 }

--- a/web/themes/custom/asulib_barrio/asulib_barrio.theme
+++ b/web/themes/custom/asulib_barrio/asulib_barrio.theme
@@ -140,4 +140,7 @@ function asulib_barrio_preprocess_block(&$variables) {
   if ($variables['plugin_id'] == 'asu_item_is_part_of') {
     $variables['is_metadata_page'] = (\Drupal::routeMatch()->getRouteName() == "asu_item_extras.full_metadata_view");
   }
+  if ($variables['plugin_id'] == "explore_this_item_block" && empty($variables['content'])) {
+    $variables['attributes']['hidden'] = TRUE;
+  }
 }


### PR DESCRIPTION
this enhancement makes no changes to the config, so after pulling in this branch and doing `drush cr`, the "Explore this item" block should only appear when there would be any relevant link in that block - based on access and even model. The theme code for the preprocess_block method has been adjusted to set the block's hidden property based on whether or not there is any content for the block.

To test, navigate to any items that has either: restricted content and the current user does not have "View" access to it, or an item that has the model of "Binary", "Audio" or "Video" (since these two would have the viewer based code already on the "overview page" for the item ie: items/12345.