### PR TITLE
Item breadcrumb 395

### DIFF
--- a/web/modules/custom/asu_breadcrumbs/src/ASUBreadcrumbBuilder.php
+++ b/web/modules/custom/asu_breadcrumbs/src/ASUBreadcrumbBuilder.php
@@ -58,7 +58,7 @@ class ASUBreadcrumbBuilder implements BreadcrumbBuilderInterface {
    * @param \Drupal\\Core\\Render\\Renderer $renderer
    *   Drupal core renderer.
    */
-  public function __construct(EntityTypeManagerInterface $entity_manager, ConfigFactoryInterface $config_factory, Renderer $renderer /*, EntityTypeManager $entityTypeManager */) {
+  public function __construct(EntityTypeManagerInterface $entity_manager, ConfigFactoryInterface $config_factory, Renderer $renderer) {
     $this->nodeStorage = $entity_manager->getStorage('node');
     $this->mediaStorage = $entity_manager->getStorage('media');
     $this->config = $config_factory->get('asu_breadcrumbs.breadcrumbs');
@@ -128,11 +128,10 @@ class ASUBreadcrumbBuilder implements BreadcrumbBuilderInterface {
       $bundle = $node->bundle();
       $route_name = $route_match->getRouteName();
       // Need to also include the canonical view of any node.
-      \Drupal::logger('asu search')->info('$route_name = ' . print_r($route_name, TRUE));
       $is_node_or_node_subpage = (
         ($route_name == 'asu_item_extras.full_metadata_view') ||
         ($route_name == 'asu_item_extras.complex_object_members') ||
-        ($route_name == 'asu_item_extras.viewer_controller_render_view') || 
+        ($route_name == 'asu_item_extras.viewer_controller_render_view') ||
         ($route_name == 'view.media_of.page_1'));
       $is_collection_subpage =
         ($route_name == 'asu_statistics.collection_statistics_view');


### PR DESCRIPTION
This minor enhancement should display the media's node as a link in the breadcrumb trail.

There is no config change -- so this should be active after checking out the branch and running `drush cr`.

To test, navigate to various items' media pages and see that the breadcrumb list for each have a link to the actual node that the media is related... 

This code does not add the "/ Media" at the end that is just text (such as the search breadcrumbs where it shows the "Search for TERM" or an item breadcrumb where it simply lists the name of the node). That was not originally part of the issue, but it could be achieved by editing the theme code a little bit.