### PR TITLE
prevent fatal error when item does not have any media attached for #404

### DIFF
--- a/web/modules/custom/asu_item_extras/src/Plugin/Block/DownloadsBlock.php
+++ b/web/modules/custom/asu_item_extras/src/Plugin/Block/DownloadsBlock.php
@@ -127,7 +127,8 @@ class DownloadsBlock extends BlockBase implements ContainerFactoryPluginInterfac
     $servicefile_term = $islandora_utils->getTermForUri('http://pcdm.org/use#ServiceFile');
     $servicefile = $islandora_utils->getMediaWithTerm($node, $servicefile_term);
     if ($origfile) {
-      $of_access = $origfile->get('field_access_terms')->referencedEntities()[0]->label();
+      $file_entities = ($origfile->hasField('field_access_terms') ? $origfile->get('field_access_terms')->referencedEntities() : NULL);
+      $of_access = ((!is_null($file_entities) && array_key_exists(0, $file_entities)) ? $file_entities[0]->label() : FALSE);
       $source_field = $media_source_service->getSourceFieldName($origfile->bundle());
       if (!empty($source_field)) {
         $of_file = $origfile->get($source_field)->referencedEntities()[0];
@@ -139,8 +140,8 @@ class DownloadsBlock extends BlockBase implements ContainerFactoryPluginInterfac
       // TODO populate $download_info with the filesize in human readable format and the extension of the fiel
     }
     if ($servicefile) {
-      $sf_access =
-        $servicefile->get('field_access_terms')->referencedEntities()[0]->label();
+      $file_entities = ($servicefile->hasField('field_access_terms') ? $servicefile->get('field_access_terms')->referencedEntities() : NULL);
+      $sf_access = ((!is_null($file_entities) && array_key_exists(0, $file_entities)) ? $file_entities[0]->label() : FALSE);
       $source_field = $media_source_service->getSourceFieldName($servicefile->bundle());
       if (!empty($source_field)) {
         $sf_file = $servicefile->get($source_field)->referencedEntities()[0];

--- a/web/modules/custom/asu_item_extras/templates/file-video-caption.html.twig
+++ b/web/modules/custom/asu_item_extras/templates/file-video-caption.html.twig
@@ -1,0 +1,33 @@
+{#
+/**
+* @file
+* Default theme implementation to display the file entity as a video tag.
+*
+* Available variables:
+* - attributes: An array of HTML attributes, intended to be added to the
+*   video tag.
+* - files: And array of files to be added as sources for the video tag. Each
+*   element is an array with the following elements:
+*   - file: The full file object.
+*   - source_attributes: An array of HTML attributes for to be added to the
+*     source tag.
+* - caption: the captions file
+* - poster: the poster (thumbnail) file
+*
+* @ingroup themeable
+*/
+#}
+{% if poster %}
+  <video controls width="100%" poster="{{ poster }}" crossorigin="anonymous">
+{% else %}
+  <video controls width="100%" crossorigin="anonymous">
+{% endif %}
+  {% for file in files %}
+    <source {{ file.source_attributes }} crossorigin="anonymous" />
+  {% endfor %}
+  {% if caption %}
+    <track src="{{ caption }}" kind="captions" crossorigin="anonymous">
+  {% endif %}
+Your browser does not support the video tag. Please <a href="{{path("entity.webform.canonical",  {"webform": "feedback"})}}">
+report this issue</a> with your browser information so we can improve our platform.
+</video>


### PR DESCRIPTION
This change to the block logic prevents a fatal error when an item does not have any media attached. To test, checkout the branch and clear the cache -- and view any items that do not have any media attached.