### PR TITLE
made link for both image or glyph display for search results for #351

### DIFF
--- a/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--search-result.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--search-result.html.twig
@@ -90,12 +90,12 @@
   <div{{ content_attributes.addClass('node__content', 'clearfix', 'row', 'item-result') }}>
     <div class="col-md-2">
       {% if complex_obj_thumb is not empty %}
-        <img src=" {{ complex_obj_thumb }}"/>
+        <a href="/items/{{ node.id }}"><img src=" {{ complex_obj_thumb }}"/></a>
       {% elseif drupal_view_result('display_media', 'thumbnail', node.id) is empty %}
         {% set mod = content.field_model[0]|render|trim %}
         {% for k, v in model_icons|filter((v, k) => k == mod) -%}
           <div class="icon-container">
-            <i class="{{ v }} fa-6x"></i>
+            <a href="/items/{{ node.id }}"><i class="{{ v }} fa-6x"></i></a>
           </div>
         {% endfor %}
       {% else %}


### PR DESCRIPTION
This only updates the image or glyphs in search results to be a link to the items/{nid} page... the part in the issue about adding a border has not been done in this branch.

Since this change is only to a single twig file, to test just pull down the branch and clear the cache and then view any search results page that shows either thumbnail images or the glyph. Make sure that these link to the expected item page.