### PR TITLE
Taxonomy create 236

### DIFF
--- a/config/sync/core.entity_form_display.taxonomy_term.conference.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.conference.default.yml
@@ -6,8 +6,29 @@ dependencies:
     - taxonomy.vocabulary.conference
   module:
     - controlled_access_terms
+    - field_group
     - path
     - text
+third_party_settings:
+  field_group:
+    group_advanced_fields:
+      children:
+        - description
+        - langcode
+        - translation
+        - path
+        - status
+      parent_name: ''
+      weight: 2
+      format_type: details
+      region: content
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        open: false
+        required_fields: true
+      label: 'Advanced fields'
 id: taxonomy_term.conference.default
 targetEntityType: taxonomy_term
 bundle: conference
@@ -15,14 +36,14 @@ mode: default
 content:
   description:
     type: text_textarea
-    weight: 0
+    weight: 3
     region: content
     settings:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
   field_authority_link:
-    weight: 101
+    weight: 1
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -31,14 +52,14 @@ content:
     region: content
   langcode:
     type: language_select
-    weight: 2
+    weight: 4
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   name:
     type: string_textfield
-    weight: -5
+    weight: 0
     region: content
     settings:
       size: 60
@@ -46,7 +67,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 30
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -54,11 +75,11 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 100
+    weight: 7
     region: content
     third_party_settings: {  }
   translation:
-    weight: 10
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.taxonomy_term.corporate_body.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.corporate_body.default.yml
@@ -11,8 +11,33 @@ dependencies:
     - taxonomy.vocabulary.corporate_body
   module:
     - controlled_access_terms
+    - field_group
     - path
     - text
+third_party_settings:
+  field_group:
+    group_advanced_fields:
+      children:
+        - langcode
+        - path
+        - field_cat_date_begin
+        - field_cat_date_end
+        - field_corp_alt_name
+        - description
+        - field_relationships
+        - translation
+        - status
+      parent_name: ''
+      weight: 3
+      format_type: details
+      region: content
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        open: false
+        required_fields: true
+      label: 'Advanced fields'
 id: taxonomy_term.corporate_body.default
 targetEntityType: taxonomy_term
 bundle: corporate_body
@@ -20,14 +45,14 @@ mode: default
 content:
   description:
     type: text_textarea
-    weight: 7
+    weight: 9
     settings:
       rows: 9
       placeholder: ''
     third_party_settings: {  }
     region: content
   field_authority_link:
-    weight: 3
+    weight: 1
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -35,7 +60,7 @@ content:
     type: authority_link_default
     region: content
   field_cat_date_begin:
-    weight: 4
+    weight: 6
     settings:
       strict_dates: false
       intervals: false
@@ -44,7 +69,7 @@ content:
     type: edtf_default
     region: content
   field_cat_date_end:
-    weight: 5
+    weight: 7
     settings:
       strict_dates: false
       intervals: false
@@ -53,7 +78,7 @@ content:
     type: edtf_default
     region: content
   field_corp_alt_name:
-    weight: 6
+    weight: 8
     settings:
       rows: 5
       placeholder: ''
@@ -71,14 +96,14 @@ content:
     type: typed_relation_default
     region: content
   field_type:
-    weight: 1
+    weight: 2
     settings: {  }
     third_party_settings: {  }
     type: options_select
     region: content
   langcode:
     type: language_select
-    weight: 2
+    weight: 4
     region: content
     settings:
       include_locked: true
@@ -93,7 +118,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 2
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -101,11 +126,11 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 100
+    weight: 12
     region: content
     third_party_settings: {  }
   translation:
-    weight: 10
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.taxonomy_term.family.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.family.default.yml
@@ -9,23 +9,47 @@ dependencies:
     - taxonomy.vocabulary.family
   module:
     - controlled_access_terms
+    - field_group
     - path
     - text
+third_party_settings:
+  field_group:
+    group_advanced_fields:
+      children:
+        - description
+        - langcode
+        - field_cat_date_begin
+        - field_cat_date_end
+        - translation
+        - path
+        - status
+        - field_relationships
+      parent_name: ''
+      weight: 2
+      format_type: details
+      region: content
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        open: false
+        required_fields: true
+      label: 'Advanced fields'
 id: taxonomy_term.family.default
 targetEntityType: taxonomy_term
 bundle: family
 mode: default
 content:
   description:
-    type: text_textfield
-    weight: 0
+    type: text_textarea
+    weight: 3
     region: content
     settings:
-      size: 60
       placeholder: ''
+      rows: 5
     third_party_settings: {  }
   field_authority_link:
-    weight: 122
+    weight: 1
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -33,23 +57,25 @@ content:
     type: authority_link_default
     region: content
   field_cat_date_begin:
-    weight: 8
+    weight: 5
     settings:
       strict_dates: false
       intervals: false
+      sets: false
     third_party_settings: {  }
     type: edtf_default
     region: content
   field_cat_date_end:
-    weight: 9
+    weight: 6
     settings:
       strict_dates: false
       intervals: false
+      sets: false
     third_party_settings: {  }
     type: edtf_default
     region: content
   field_relationships:
-    weight: 123
+    weight: 10
     settings:
       match_operator: CONTAINS
       size: '60'
@@ -60,14 +86,14 @@ content:
     region: content
   langcode:
     type: language_select
-    weight: 2
+    weight: 4
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   name:
     type: string_textfield
-    weight: -5
+    weight: 0
     region: content
     settings:
       size: 60
@@ -75,7 +101,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 30
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -83,12 +109,12 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 100
+    weight: 9
     region: content
     third_party_settings: {  }
   translation:
-    weight: 10
+    weight: 7
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
 hidden: {  }

--- a/config/sync/core.entity_form_display.taxonomy_term.person.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.person.default.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.taxonomy_term.person.field_alternate_name
     - field.field.taxonomy_term.person.field_authority_link
     - field.field.taxonomy_term.person.field_cat_date_begin
     - field.field.taxonomy_term.person.field_cat_date_end
@@ -9,8 +10,45 @@ dependencies:
     - taxonomy.vocabulary.person
   module:
     - controlled_access_terms
+    - field_group
     - path
     - text
+third_party_settings:
+  field_group:
+    group_advanced_fields:
+      children:
+        - langcode
+        - description
+        - translation
+        - path
+        - field_cat_date_begin
+        - field_cat_date_end
+        - field_relationships
+        - status
+      parent_name: ''
+      weight: 2
+      format_type: details
+      region: content
+      format_settings:
+        id: ''
+        classes: ''
+        effect: none
+        open: false
+        required_fields: true
+      label: 'Advanced fields'
+    group_fields:
+      children: {  }
+      parent_name: ''
+      weight: 4
+      format_type: accordion_item
+      region: hidden
+      format_settings:
+        id: ''
+        classes: ''
+        formatter: closed
+        required_fields: true
+        description: ''
+      label: Fields
 id: taxonomy_term.person.default
 targetEntityType: taxonomy_term
 bundle: person
@@ -18,12 +56,12 @@ mode: default
 content:
   description:
     type: text_textarea
-    weight: 10
+    weight: 22
+    region: content
     settings:
-      rows: 9
+      rows: 5
       placeholder: ''
     third_party_settings: {  }
-    region: content
   field_authority_link:
     weight: 1
     settings:
@@ -33,43 +71,43 @@ content:
     type: authority_link_default
     region: content
   field_cat_date_begin:
-    weight: 26
+    type: edtf_default
+    weight: 25
+    region: content
     settings:
       strict_dates: false
-      intervals: false
+      intervals: true
       sets: false
     third_party_settings: {  }
-    type: edtf_default
-    region: content
   field_cat_date_end:
-    weight: 27
+    type: edtf_default
+    weight: 26
+    region: content
     settings:
       strict_dates: false
-      intervals: false
+      intervals: true
       sets: false
     third_party_settings: {  }
-    type: edtf_default
-    region: content
   field_relationships:
-    weight: 29
+    type: typed_relation_default
+    weight: 27
+    region: content
     settings:
       match_operator: CONTAINS
-      size: '60'
-      placeholder: ''
       match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
-    type: typed_relation_default
-    region: content
   langcode:
     type: language_select
-    weight: 2
+    weight: 21
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   name:
     type: string_textfield
-    weight: -5
+    weight: 0
     region: content
     settings:
       size: 60
@@ -77,20 +115,21 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 8
+    weight: 24
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
+    weight: 28
+    region: content
     settings:
       display_label: true
-    weight: 100
-    region: content
     third_party_settings: {  }
   translation:
-    weight: 10
+    weight: 23
     region: content
     settings: {  }
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  field_alternate_name: true


### PR DESCRIPTION
Adjusted the default form display for the taxonomy vocabulary "create page" for Person, Corporate Body, Convention, and Family so that only Name and Authority Source are top level (with all other fields put into a Details group that is labelled Advanced fields.

The autocomplete component on the ASU Repository Item edit page is unchanged.

To test, pull in the code for this branch and clear the cache. After this, edit any existing ASU Repository Item (or create a new test item) ... and test the links that appear in the description for the "Linked Agents" field to "add a person", "add a corporate body", or "add an event".