### PR TITLE
Added a formatter for string_long fields in output

### DIFF
--- a/config/sync/core.entity_view_display.paragraph.complex_note.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.complex_note.default.yml
@@ -5,6 +5,8 @@ dependencies:
     - field.field.paragraph.complex_note.field_note_text
     - field.field.paragraph.complex_note.field_note_type
     - paragraphs.paragraphs_type.complex_note
+  module:
+    - asu_item_extras
 id: paragraph.complex_note.default
 targetEntityType: paragraph
 bundle: complex_note
@@ -15,7 +17,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    type: basic_string
+    type: auto_link_text
     region: content
   field_note_type:
     weight: 1

--- a/web/modules/custom/asu_item_extras/src/Plugin/Field/FieldFormatter/AutoLinkTextFormatter.php
+++ b/web/modules/custom/asu_item_extras/src/Plugin/Field/FieldFormatter/AutoLinkTextFormatter.php
@@ -34,7 +34,7 @@ class AutoLinkTextFormatter extends FormatterBase {
 
   private function auto_link_text($string) {
     $url = '@(http(s)?)?(://)?(([a-zA-Z])([-\w]+\.)+([^\s\.]+[^\s]*)+[^,.\s])@';
-    $string = preg_replace($url, '<a href="http$2://$4" target="_blank" title="$0">$0</a>', $string);
+    $string = preg_replace($url, '<a href="http$2://$4" target="_blank" title="$0">$0<span class="visually-hidden">, opens in a new window</span></a>', $string);
 
     return $string;
   }

--- a/web/modules/custom/asu_item_extras/src/Plugin/Field/FieldFormatter/AutoLinkTextFormatter.php
+++ b/web/modules/custom/asu_item_extras/src/Plugin/Field/FieldFormatter/AutoLinkTextFormatter.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Drupal\asu_item_extras\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
+
+/**
+ * Plugin implementation of the 'AutoLinkTextFormatter'.
+ *
+ * @FieldFormatter(
+ *   id = "auto_link_text",
+ *   label = @Translation("Auto_link text"),
+ *   field_types = {
+ *     "string_long"
+ *   }
+ * )
+ */
+class AutoLinkTextFormatter extends FormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+    foreach ($items as $delta => $item) {
+      $item_text = $item->get('value')->getValue();
+      $elements[$delta]['#markup'] = $this->auto_link_text($item_text);
+    }
+
+    return $elements;
+  }
+
+
+  private function auto_link_text($string) {
+    $url = '@(http(s)?)?(://)?(([a-zA-Z])([-\w]+\.)+([^\s\.]+[^\s]*)+[^,.\s])@';
+    $string = preg_replace($url, '<a href="http$2://$4" target="_blank" title="$0">$0</a>', $string);
+
+    return $string;
+  }
+}

--- a/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--full-metadata.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--full-metadata.html.twig
@@ -85,7 +85,7 @@
     {{ content|without('field_note_para') }}
     {# Check if the note paragraph has any content #}
     {% if (content.field_note_para.0['#paragraph'].field_note_text is not empty) or (content.field_note_para.0['#paragraph'].field_note_type is not empty) %}
-      {{ content.field_note_para|raw }}
+      {{ content.field_note_para }}
     {% endif %}
     {% if drupal_view('collaborating_institutions', 'block_1', node.id)|render|striptags|trim|length > 0 %}
       <div class="collab field row">

--- a/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--full-metadata.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--full-metadata.html.twig
@@ -85,7 +85,7 @@
     {{ content|without('field_note_para') }}
     {# Check if the note paragraph has any content #}
     {% if (content.field_note_para.0['#paragraph'].field_note_text is not empty) or (content.field_note_para.0['#paragraph'].field_note_type is not empty) %}
-      {{ content.field_note_para }}
+      {{ content.field_note_para|raw }}
     {% endif %}
     {% if drupal_view('collaborating_institutions', 'block_1', node.id)|render|striptags|trim|length > 0 %}
       <div class="collab field row">


### PR DESCRIPTION
Notes is a complex_note paragraph field - which is now configured to use a new formatter that will auto-link any text.

To test, check out this branch and import the single core.entity_view_display.paragraph.complex_note.default.yml configuration change and then clear the cache. Navigate to any item that has a Note value that contains an http:// or https:// link (or edit one / add a note to any item) and view the item's full metadata page.

NOTE: the links do open in a new tab. If it is deemed that they should open in the same tab, some minor changes to the formatter would be needed in order to make this configurable. Also, there is no title attribute, but the screen-reader info is added to these.