### PR TITLE
Validation codefixes to pass MODS schema validation

### DIFF
--- a/web/modules/custom/asu_mods/config/install/asu_mods.asu_repository_item.yml
+++ b/web/modules/custom/asu_mods/config/install/asu_mods.asu_repository_item.yml
@@ -141,13 +141,13 @@ field_resource_type:
   '@valueURI': field_external_authority_link/uri
   '#': name
 field_geographic_subject:
-  '_top': subject_geo
+  '_top': subject
   geographic:
     '@authority': field_authority_link/source
     '@valueURI': field_authority_link/uri
     '#': name
 field_temporal_subject:
-  '_top': subject_temp
+  '_top': subject
   temporal:
     # '@point': todo
     # '@encoding': todo
@@ -155,13 +155,13 @@ field_temporal_subject:
     '@valueURI': field_authority_link/uri
     '#': name
 field_subject:
-  '_top': subject_subj
+  '_top': subject
   topic:
     '@authority': field_authority_link/source
     '@valueURI': field_authority_link/uri
     '#': name
 field_subjects_name:
-  '_top': subject_name
+  '_top': subject
   name:
     '@authority': field_authority_link/source
     '@valueURI': field_authority_link/uri
@@ -171,7 +171,7 @@ field_subjects_name:
   # subject:
 # # TODO - figure out the storage on this one
 field_title_subject:
-  '_top': subject_tit
+  '_top': subject
   title:
     '@authority': field_authority_link/source
     '@valueURI': field_authority_link/uri

--- a/web/modules/custom/asu_mods/config/install/asu_mods.asu_repository_item.yml
+++ b/web/modules/custom/asu_mods/config/install/asu_mods.asu_repository_item.yml
@@ -141,13 +141,13 @@ field_resource_type:
   '@valueURI': field_external_authority_link/uri
   '#': name
 field_geographic_subject:
-  '_top': subject
+  '_top': subject_geo
   geographic:
     '@authority': field_authority_link/source
     '@valueURI': field_authority_link/uri
     '#': name
 field_temporal_subject:
-  '_top': subject
+  '_top': subject_temp
   temporal:
     # '@point': todo
     # '@encoding': todo
@@ -155,13 +155,13 @@ field_temporal_subject:
     '@valueURI': field_authority_link/uri
     '#': name
 field_subject:
-  '_top': subject
+  '_top': subject_subj
   topic:
     '@authority': field_authority_link/source
     '@valueURI': field_authority_link/uri
     '#': name
 field_subjects_name:
-  '_top': subject
+  '_top': subject_name
   name:
     '@authority': field_authority_link/source
     '@valueURI': field_authority_link/uri
@@ -171,7 +171,7 @@ field_subjects_name:
   # subject:
 # # TODO - figure out the storage on this one
 field_title_subject:
-  '_top': subject
+  '_top': subject_tit
   title:
     '@authority': field_authority_link/source
     '@valueURI': field_authority_link/uri

--- a/web/modules/custom/asu_mods/src/Encoder/ModsEncoder.php
+++ b/web/modules/custom/asu_mods/src/Encoder/ModsEncoder.php
@@ -97,8 +97,15 @@ class ModsEncoder extends XmlEncoder {
           }
           if ($cv == "bundle") {
             $cv = $val->bundle();
-            if ($cv == 'person') {
-              $cv = 'personal';
+            switch ($cv) {
+              // MODS schema requires "personal".
+              case 'person':
+                $cv = 'personal';
+                break;
+              // MODS schema requires "Corporate".
+              case 'corporate_body':
+                $cv = 'Corporate';
+                break;
             }
           }
           elseif ($ck == "@supplied") {
@@ -271,6 +278,7 @@ class ModsEncoder extends XmlEncoder {
         }
       }
     }
+
     return $this->fixData($new_data);
   }
 

--- a/web/modules/custom/asu_mods/src/Encoder/ModsEncoder.php
+++ b/web/modules/custom/asu_mods/src/Encoder/ModsEncoder.php
@@ -104,7 +104,7 @@ class ModsEncoder extends XmlEncoder {
                 break;
               // MODS schema requires "Corporate".
               case 'corporate_body':
-                $cv = 'Corporate';
+                $cv = 'corporate';
                 break;
             }
           }


### PR DESCRIPTION
This enhancement should only slightly modify how the MODS fine is created for an item such as ./items/123?_format=mods. It merely contains adjustments to the subject containers when rendering and for linked agent field, it maps corporate_body to the MODS required value of Corporation.

To test, pull down this branch and navigate to an item's (edit the Agent value as needed) MODS and run a schema validation on the resultant XML. An online tool such as https://www.freeformatter.com/xml-validator-xsd.html is helpful (but xmlint in the terminal should be able to be used as well).