### PR TITLE
adjustment to Copy Link button for #419

### DIFF
--- a/web/modules/custom/asu_item_extras/css/asu_item_extras.css
+++ b/web/modules/custom/asu_item_extras/css/asu_item_extras.css
@@ -1,6 +1,6 @@
 /**
  * CSS to control individual classes that are used in block code for containers
- ============================================================================ */
+≈ ============================================================================ */
 .float_l_18,
 .float_l_80,
 .float_l_49 {
@@ -75,9 +75,9 @@
   background-color: #fff !important;
   padding: 0.25rem !important;
 }
-.iiif input,
-.iiif .btn {
-  border-radius: 0;
+
+#copy_manifest_link {
+  line-height: 24px;
 }
 
 li.rrssb-email a,

--- a/web/modules/custom/asu_item_extras/src/Plugin/Block/ASUItemIIIF.php
+++ b/web/modules/custom/asu_item_extras/src/Plugin/Block/ASUItemIIIF.php
@@ -142,7 +142,7 @@ class ASUItemIIIF extends BlockBase implements ContainerFactoryPluginInterface {
             '#suffix' => '<!-- Unnamed (Rectangle) -->
             </div>
             <div class="col">
-              <a id="copy_manifest_link" class="btn btn-primary copy_button">Copy link</a>
+              <a id="copy_manifest_link" class="btn btn-maroon btn-md">Copy link</a>
             </div>
             </div>
             </div>


### PR DESCRIPTION
This tiny change should close #419 

To test, navigate to any item that is an Image (model) and view the IIIF block to see that the button is now rounded and has the css styles `btn btn-maroon btn-md` instead of the former classes.