### PR TITLE
adjusted theme code to display as clickable link

### DIFF
--- a/web/themes/custom/asulib_barrio/asulib_barrio.theme
+++ b/web/themes/custom/asulib_barrio/asulib_barrio.theme
@@ -120,20 +120,16 @@ function asulib_barrio_preprocess_paragraph(&$variables) {
     // If the value has http:// or https:// then use that link value, else
     // create a link that is https://doi.
     preg_match_all('/^http(s?):\/\//m', $identifier_value, $matches, PREG_SET_ORDER, 0);
+    $variables['Identifier_link_label'] = $paragraph->get('field_identifier_type')->referencedEntities()[0]->label();
     if (count($matches) > 0) {
       // Value is a link already.
       $url = Url::fromUri($identifier_value);
-      if ($paragraph->get('field_identifier_type')->referencedEntities()[0]->label() == 'Digital object identifier') {
-        $variables['DOI_link'] = Link::fromTextAndUrl($identifier_value, $url);
-      } else {
-        $variables['Identifier_link_label'] = $paragraph->get('field_identifier_type')->referencedEntities()[0]->label();
-        $variables['Identifier_link'] = Link::fromTextAndUrl($identifier_value, $url);
-      }
+      $variables['Identifier_link'] = Link::fromTextAndUrl($identifier_value, $url);
     }
     // ONLY for DOI links, convert a string into the https://doi.org/{STRING_VALUE}.
     elseif ($paragraph->get('field_identifier_type')->referencedEntities()[0]->label() == 'Digital object identifier') {
       $url = Url::fromUri('https://doi.org/' . $identifier_value);
-      $variables['DOI_link'] = Link::fromTextAndUrl($identifier_value, $url);
+      $variables['Identifier_link'] = Link::fromTextAndUrl($identifier_value, $url);
     }
   }
 }

--- a/web/themes/custom/asulib_barrio/asulib_barrio.theme
+++ b/web/themes/custom/asulib_barrio/asulib_barrio.theme
@@ -115,8 +115,7 @@ function asulib_barrio_preprocess_node(&$variables) {
 function asulib_barrio_preprocess_paragraph(&$variables) {
   $paragraph = $variables['paragraph'];
   if ($paragraph->bundle() == 'typed_identifier' && $paragraph->hasField('field_identifier_type') &&
-    !is_null($paragraph->get('field_identifier_type')->entity) &&
-    $paragraph->get('field_identifier_type')->referencedEntities()[0]->label() == 'Digital object identifier') {
+    !is_null($paragraph->get('field_identifier_type')->entity)) {
     $identifier_value = $paragraph->get('field_identifier_value')->value;
     // If the value has http:// or https:// then use that link value, else
     // create a link that is https://doi.
@@ -124,9 +123,15 @@ function asulib_barrio_preprocess_paragraph(&$variables) {
     if (count($matches) > 0) {
       // Value is a link already.
       $url = Url::fromUri($identifier_value);
-      $variables['DOI_link'] = Link::fromTextAndUrl($identifier_value, $url);
+      if ($paragraph->get('field_identifier_type')->referencedEntities()[0]->label() == 'Digital object identifier') {
+        $variables['DOI_link'] = Link::fromTextAndUrl($identifier_value, $url);
+      } else {
+        $variables['Identifier_link_label'] = $paragraph->get('field_identifier_type')->referencedEntities()[0]->label();
+        $variables['Identifier_link'] = Link::fromTextAndUrl($identifier_value, $url);
+      }
     }
-    else {
+    // ONLY for DOI links, convert a string into the https://doi.org/{STRING_VALUE}.
+    elseif ($paragraph->get('field_identifier_type')->referencedEntities()[0]->label() == 'Digital object identifier') {
       $url = Url::fromUri('https://doi.org/' . $identifier_value);
       $variables['DOI_link'] = Link::fromTextAndUrl($identifier_value, $url);
     }

--- a/web/themes/custom/asulib_barrio/templates/field/paragraph--typed-identifier.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/field/paragraph--typed-identifier.html.twig
@@ -49,9 +49,7 @@
 {% block paragraph %}
   <div{{ attributes.addClass(classes) }}>
     {% block content %}
-      {% if DOI_link %}
-        Digital object identifier: {{ DOI_link }}
-      {% elseif Identifier_link %}
+      {% if Identifier_link %}
         {{ Identifier_link_label }}: {{ Identifier_link }}
       {% else %}
         {{ content }}

--- a/web/themes/custom/asulib_barrio/templates/field/paragraph--typed-identifier.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/field/paragraph--typed-identifier.html.twig
@@ -51,6 +51,8 @@
     {% block content %}
       {% if DOI_link %}
         Digital object identifier: {{ DOI_link }}
+      {% elseif Identifier_link %}
+        {{ Identifier_link_label }}: {{ Identifier_link }}
       {% else %}
         {{ content }}
       {% endif %}


### PR DESCRIPTION
This should close the issue #415 

To test, review any item that has a typed identifier value that starts with either https:// or http:// -- view the link and the appropriate typed identifier label prefix on either the main item overview page or the item metadata page. Also, confirm that any typed identifiers that are "Digital Object Identifiers" are still converted to links for {STRING_VALUE} to become https://doi.org/{STRING_VALUE}.