### PR TITLE
adjustments to handle the file with remote_video media type

### DIFF
--- a/config/sync/core.entity_form_display.media.remote_video.default.yml
+++ b/config/sync/core.entity_form_display.media.remote_video.default.yml
@@ -3,6 +3,8 @@ status: true
 dependencies:
   config:
     - field.field.media.remote_video.field_media_oembed_video
+    - field.field.media.remote_video.field_media_of
+    - field.field.media.remote_video.field_media_use
     - media.type.remote_video
   module:
     - media
@@ -25,6 +27,22 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+    region: content
+  field_media_of:
+    weight: 101
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  field_media_use:
+    weight: 102
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
     region: content
   langcode:
     type: language_select

--- a/config/sync/core.entity_view_display.media.remote_video.default.yml
+++ b/config/sync/core.entity_view_display.media.remote_video.default.yml
@@ -3,6 +3,8 @@ status: true
 dependencies:
   config:
     - field.field.media.remote_video.field_media_oembed_video
+    - field.field.media.remote_video.field_media_of
+    - field.field.media.remote_video.field_media_use
     - media.type.remote_video
   module:
     - media
@@ -16,12 +18,14 @@ content:
     weight: 0
     label: hidden
     settings:
-      max_width: 0
-      max_height: 0
+      max_width: 640
+      max_height: 480
     third_party_settings: {  }
     region: content
 hidden:
   created: true
+  field_media_of: true
+  field_media_use: true
   langcode: true
   name: true
   search_api_excerpt: true

--- a/config/sync/field.field.media.remote_video.field_media_of.yml
+++ b/config/sync/field.field.media.remote_video.field_media_of.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_of
+    - media.type.remote_video
+id: media.remote_video.field_media_of
+field_name: field_media_of
+entity_type: media
+bundle: remote_video
+label: 'Media of'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/sync/field.field.media.remote_video.field_media_use.yml
+++ b/config/sync/field.field.media.remote_video.field_media_use.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_use
+    - media.type.remote_video
+    - taxonomy.vocabulary.islandora_media_use
+id: media.remote_video.field_media_use
+field_name: field_media_use
+entity_type: media
+bundle: remote_video
+label: 'Media Use'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      islandora_media_use: islandora_media_use
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/web/modules/custom/asu_item_extras/src/Plugin/Block/ASUItemDownloads.php
+++ b/web/modules/custom/asu_item_extras/src/Plugin/Block/ASUItemDownloads.php
@@ -107,7 +107,7 @@ class ASUItemDownloads extends BlockBase implements ContainerFactoryPluginInterf
       $download_count = 0;
       foreach ($mids as $mid) {
         $fid = $this->islandoraMatomo->getFileFromMedia($mid);
-        $download_count += $this->islandoraMatomo->getDownloadsForFile(['fid' => $fid]);
+        $download_count += ($fid) ? $this->islandoraMatomo->getDownloadsForFile(['fid' => $fid]) : 0;
       }
       return [
         '#cache' => ['max-age' => 0],

--- a/web/modules/custom/asu_item_extras/src/Plugin/Block/DownloadsBlock.php
+++ b/web/modules/custom/asu_item_extras/src/Plugin/Block/DownloadsBlock.php
@@ -138,7 +138,7 @@ class DownloadsBlock extends BlockBase implements ContainerFactoryPluginInterfac
       $of_access = ((!is_null($file_entities) && array_key_exists(0, $file_entities)) ? $file_entities[0]->label() : FALSE);
       $source_field = $media_source_service->getSourceFieldName($origfile->bundle());
       if (!empty($source_field)) {
-        $of_file = ($origfile->hasField($source_field) && (is_object($orig_file->get($source_field))) ? $origfile->get($source_field)->referencedEntities()[0] : FALSE);
+        $of_file = ($origfile->hasField($source_field) && (is_object($origfile->get($source_field))) ? $origfile->get($source_field)->referencedEntities()[0] : FALSE);
         if ($of_file) {
           $of_uri = $islandora_utils->getDownloadUrl($of_file);
           $of_link = Link::fromTextAndUrl($this->t('Original'), Url::fromUri($of_uri, ['attributes' => ['class' => ['dropdown-item']]]));

--- a/web/modules/custom/asu_item_extras/src/Plugin/Block/DownloadsBlock.php
+++ b/web/modules/custom/asu_item_extras/src/Plugin/Block/DownloadsBlock.php
@@ -122,7 +122,8 @@ class DownloadsBlock extends BlockBase implements ContainerFactoryPluginInterfac
         $nid = (is_string($node) ? $node : $node->id());
       }
     }
-    $download_info = $file_size = '';
+    $download_info = '';
+    $file_size = 0;
     $islandora_utils = \Drupal::service('islandora.utils');
     $media_source_service = \Drupal::service('islandora.media_source_service');
     $origfile_term = $islandora_utils->getTermForUri('http://pcdm.org/use#OriginalFile');
@@ -131,31 +132,42 @@ class DownloadsBlock extends BlockBase implements ContainerFactoryPluginInterfac
     $servicefile = $islandora_utils->getMediaWithTerm($node, $servicefile_term);
     $masterfile_term = $islandora_utils->getTermForUri('http://pcdm.org/use#PreservationMasterFile');
     $masterfile = $islandora_utils->getMediaWithTerm($node, $masterfile_term);
-    if ($origfile) {
+
+    if ($origfile && $origfile->bundle() <> 'remote_video') {
+      $file_entities = ($origfile->hasField('field_access_terms') ? $origfile->get('field_access_terms')->referencedEntities() : NULL);
+      $of_access = ((!is_null($file_entities) && array_key_exists(0, $file_entities)) ? $file_entities[0]->label() : FALSE);
       $source_field = $media_source_service->getSourceFieldName($origfile->bundle());
       if (!empty($source_field)) {
-        $of_file = $origfile->get($source_field)->referencedEntities()[0];
-        $of_uri = $islandora_utils->getDownloadUrl($of_file);
-        $of_link = Link::fromTextAndUrl($this->t('Original'), Url::fromUri($of_uri, ['attributes' => ['class' => ['dropdown-item']]]));
-        $file_size = $origfile->get('field_file_size')->value;
-        $download_info .= " " . $origfile->get('field_mime_type')->value;
+        $of_file = ($origfile->hasField($source_field) && (is_object($orig_file->get($source_field))) ? $origfile->get($source_field)->referencedEntities()[0] : FALSE);
+        if ($of_file) {
+          $of_uri = $islandora_utils->getDownloadUrl($of_file);
+          $of_link = Link::fromTextAndUrl($this->t('Original'), Url::fromUri($of_uri, ['attributes' => ['class' => ['dropdown-item']]]));
+          $file_size = $origfile->get('field_file_size')->value;
+          $download_info .= " " . $origfile->get('field_mime_type')->value;
+        }
       }
       // TODO populate $download_info with the filesize in human readable format and the extension of the fiel
     }
-    if ($servicefile) {
+    if ($servicefile && $servicefile->bundle() <> 'remote_video') {
+      $file_entities = ($servicefile->hasField('field_access_terms') ? $servicefile->get('field_access_terms')->referencedEntities() : NULL);
+      $sf_access = ((!is_null($file_entities) && array_key_exists(0, $file_entities)) ? $file_entities[0]->label() : FALSE);
       $source_field = $media_source_service->getSourceFieldName($servicefile->bundle());
-      if (!empty($source_field) && $servicefile->get($source_field)->referencedEntities()) {
-        $sf_file = $servicefile->get($source_field)->referencedEntities()[0];
-        $sf_uri = $islandora_utils->getDownloadUrl($sf_file);
-        $sf_link = Link::fromTextAndUrl($this->t('Derivative'), Url::fromUri($sf_uri, ['attributes' => ['class' => ['dropdown-item']]]));  
+      if (!empty($source_field)) {
+        $sf_file = ($servicefile->hasField($source_field) && (is_object($servicefile->get($source_field))) ? $servicefile->get($source_field)->referencedEntities()[0] : FALSE);
+        if ($sf_file) {
+          $sf_uri = $islandora_utils->getDownloadUrl($sf_file);
+          $sf_link = Link::fromTextAndUrl($this->t('Derivative'), Url::fromUri($sf_uri, ['attributes' => ['class' => ['dropdown-item']]]));
+          $download_info .= $servicefile->get('field_mime_type')->value;
+        }
       }
     }
-    if ($masterfile) {
+    if ($masterfile && $masterfile.bundle() <> 'remote_video') {
       $source_field = $media_source_service->getSourceFieldName($masterfile->bundle());
       if (!empty($source_field)) {
         $pmf_file = $masterfile->get($source_field)->referencedEntities()[0];
         $pmf_uri = $islandora_utils->getDownloadUrl($pmf_file);
         $pmf_link = Link::fromTextAndUrl($this->t('Master'), Url::fromUri($pmf_uri, ['attributes' => ['class' => ['dropdown-item']]]));
+        $download_info .= $masterfile->get('field_mime_type')->value;
       }
     }
 
@@ -174,7 +186,7 @@ class DownloadsBlock extends BlockBase implements ContainerFactoryPluginInterfac
         $links[] = $sf_link->toRenderable();
       }
     }
-    if (isset($pmf_file)) {
+    if (isset($masterfile)) {
       $access_pmf_media = $masterfile->access('view', $this->currentUser);
       if ($access_pmf_media) {
         $links[] = $pmf_link->toRenderable();
@@ -195,11 +207,10 @@ class DownloadsBlock extends BlockBase implements ContainerFactoryPluginInterfac
       '#asu_download_info' => $download_info,
       '#asu_download_restricted' => ['#markup' => $markup],
       '#asu_download_links' => $links,
+      '#file_size' => $file_size,
       '#theme' => 'asu_item_extras_downloads_block',
     ];
-    if ($file_size > 0) {
-      $return['#file_size'] = $file_size;
-    }
+
     return $return;
   }
 
@@ -207,7 +218,6 @@ class DownloadsBlock extends BlockBase implements ContainerFactoryPluginInterfac
    * {@inheritdoc}
    */
   public function getCacheTags() {
-
     $block_config = BlockBase::getConfiguration();
     if (is_array($block_config) && array_key_exists('child_node_id', $block_config)) {
       $nid = $block_config['child_node_id'];
@@ -219,7 +229,6 @@ class DownloadsBlock extends BlockBase implements ContainerFactoryPluginInterfac
       }
     }
     if (isset($nid)) {
-      // If there is node add its cachetag.
       return Cache::mergeTags(parent::getCacheTags(), ['node:' . $nid]);
     }
     else {


### PR DESCRIPTION
This feature requires that the changes to islandora_riprap and islandora_matomo have also been pulled down. The islandora_matomo code is in the `main` branch, so it should be able to be pulled straight from the islandora_matomo code (as long as the remote is set to https://github.com/asulibraries/islandora_matomo.git).

For the islandora_riprap changes, the pull request is https://github.com/mjordan/islandora_riprap/pull/48 and may or may not be merged anytime soon... until then, the fork of the code at https://github.com/asulibraries/islandora_riprap in the `remote_video_media` branch.

Without the changes above, the item overview page and item media page can throw errors since a media that is using `remote_video` does not have a "file".

There are a few configuration changes. These are to add the media type, add the "media_of" and "media_use" to that entity and to set a default size for display of these to match the size of the existing Video media type. These files are:

- config/sync/core.entity_view_display.media.remote_video.default.yml
- config/sync/core.entity_form_display.media.remote_video.default.yml 
- config/sync/field.field.media.remote_video.field_media_of.yml 
- config/sync/field.field.media.remote_video.field_media_use.yml 

After pulling in this code branch and importing the configurations listed above, clear cache, to test
1. add/edit an item to use a media of `remote_video` and set that media to point to a YouTube video URI for example
2. navigate to the item overview page (like /items/12345)
3. also navigate to the item media page (like /items/12345/media)

Please let me know if there is any issue with testing or implementing this issue.