### PR TITLE
Download stats 439 redo

### DIFF
--- a/web/modules/custom/asu_collection_extras/asu_collection_extras.module
+++ b/web/modules/custom/asu_collection_extras/asu_collection_extras.module
@@ -231,21 +231,23 @@ function asu_collection_extras_syncNodeMatomoStats($nid) {
   // \Drupal::logger('asu_collection_extras')->info('views = for ' . $item_views);
   // We only want to add the stats for the media that is "Original File",
   // "Service File", or "Preservation Master File".
-  $tid_of = \Drupal::entityTypeManager()
+  $tid_of = reset(\Drupal::entityTypeManager()
     ->getStorage('taxonomy_term')
-    ->loadByProperties(['name' => "Original File"]);
-  $tid_sf = \Drupal::entityTypeManager()
+    ->loadByProperties(['name' => "Original File"]))->id();
+  $tid_sf = reset(\Drupal::entityTypeManager()
     ->getStorage('taxonomy_term')
-    ->loadByProperties(['name' => "Service File"]);
-  $tid_pmf = \Drupal::entityTypeManager()
+    ->loadByProperties(['name' => "Service File"]))->id();
+  $tid_pmf = reset(\Drupal::entityTypeManager()
     ->getStorage('taxonomy_term')
-    ->loadByProperties(['name' => "Preservation Master File"]);
+    ->loadByProperties(['name' => "Preservation Master File"]))->id();
 
   $query = \Drupal::entityQuery('media');
   $query->condition('field_media_of', $nid);
   $group = $query
     ->orConditionGroup()
-    ->condition('field_media_use', $tid_of);
+    ->condition('field_media_use', $tid_of)
+    ->condition('field_media_use', $tid_sf)
+    ->condition('field_media_use', $tid_pmf);
   $query->condition($group);
   $mids = $query->execute();
   $item_downloads = 0;

--- a/web/modules/custom/asu_collection_extras/asu_collection_extras.module
+++ b/web/modules/custom/asu_collection_extras/asu_collection_extras.module
@@ -229,26 +229,36 @@ function asu_collection_extras_syncNodeMatomoStats($nid) {
   $item_views = 0;
   $item_views += \Drupal::service('islandora_matomo.default')->getViewsForNode(['nid' => $nid]);
   // \Drupal::logger('asu_collection_extras')->info('views = for ' . $item_views);
-  // We only want to add the stats for the media that is "Original File",
-  // "Service File", or "Preservation Master File".
-  $tid_of = reset(\Drupal::entityTypeManager()
-    ->getStorage('taxonomy_term')
-    ->loadByProperties(['name' => "Original File"]))->id();
-  $tid_sf = reset(\Drupal::entityTypeManager()
-    ->getStorage('taxonomy_term')
-    ->loadByProperties(['name' => "Service File"]))->id();
-  $tid_pmf = reset(\Drupal::entityTypeManager()
-    ->getStorage('taxonomy_term')
-    ->loadByProperties(['name' => "Preservation Master File"]))->id();
-
   $query = \Drupal::entityQuery('media');
   $query->condition('field_media_of', $nid);
+  // We only want to add the stats for the media that is "Original File",
+  // "Service File", or "Preservation Master File".
   $group = $query
-    ->orConditionGroup()
-    ->condition('field_media_use', $tid_of)
-    ->condition('field_media_use', $tid_sf)
-    ->condition('field_media_use', $tid_pmf);
-  $query->condition($group);
+    ->orConditionGroup();
+  $of = \Drupal::entityTypeManager()
+    ->getStorage('taxonomy_term')
+    ->loadByProperties(['name' => "Original File"]);
+  if ($of) {
+    $tid_of = reset($of);
+    $group->condition('field_media_use', $tid_of->id());
+  }
+  $sf = \Drupal::entityTypeManager()
+    ->getStorage('taxonomy_term')
+    ->loadByProperties(['name' => "Service File"]);
+  if ($sf) {
+    $tid_sf = reset($sf);
+    $group->condition('field_media_use', $tid_sf->id());
+  }
+  $pmf = \Drupal::entityTypeManager()
+    ->getStorage('taxonomy_term')
+    ->loadByProperties(['name' => "Preservation Master File"]);
+  if ($pmf) {
+    $tid_pmf = reset($pmf);
+    $group->condition('field_media_use', $tid_pmf->id());
+  }
+  if ($of || $sf || $pmf) {
+    $query->condition($group);
+  }
   $mids = $query->execute();
   $item_downloads = 0;
   foreach ($mids as $mid) {

--- a/web/modules/custom/asu_collection_extras/asu_collection_extras.module
+++ b/web/modules/custom/asu_collection_extras/asu_collection_extras.module
@@ -229,9 +229,25 @@ function asu_collection_extras_syncNodeMatomoStats($nid) {
   $item_views = 0;
   $item_views += \Drupal::service('islandora_matomo.default')->getViewsForNode(['nid' => $nid]);
   // \Drupal::logger('asu_collection_extras')->info('views = for ' . $item_views);
-  $mids = \Drupal::entityQuery('media')
-    ->condition('field_media_of', $nid)
-    ->execute();
+  // We only want to add the stats for the media that is "Original File",
+  // "Service File", or "Preservation Master File".
+  $tid_of = \Drupal::entityTypeManager()
+    ->getStorage('taxonomy_term')
+    ->loadByProperties(['name' => "Original File"]);
+  $tid_sf = \Drupal::entityTypeManager()
+    ->getStorage('taxonomy_term')
+    ->loadByProperties(['name' => "Service File"]);
+  $tid_pmf = \Drupal::entityTypeManager()
+    ->getStorage('taxonomy_term')
+    ->loadByProperties(['name' => "Preservation Master File"]);
+
+  $query = \Drupal::entityQuery('media');
+  $query->condition('field_media_of', $nid);
+  $group = $query
+    ->orConditionGroup()
+    ->condition('field_media_use', $tid_of);
+  $query->condition($group);
+  $mids = $query->execute();
   $item_downloads = 0;
   foreach ($mids as $mid) {
     $fid = \Drupal::service('islandora_matomo.default')->getFileFromMedia($mid);


### PR DESCRIPTION
After the code is merged, the cache should be cleared just in case the route is executing stale code.

To see if the numbers for an item have a new value for downloads, navigate to that item with the specific route that is called via javascript in order to calculate this from Matomo again.. that route would be something like items/123/matomosync.

The new downloads count should be displayed on the item page beside the download button -- and that value should also be reflected in the item-collection that it contributes to for the collection download total.

This branch replaces the previous attempt that included all of the code from a different development branch as well -- so a new branch `download_stats_439_redo` is based off of `develop` and only has the relevant commits cherry-picked. The previous branch has been deleted.
