### PR TITLE
Ws2 webform stuff

### DIFF
--- a/web/themes/custom/asulib_barrio/scss/components/form.scss
+++ b/web/themes/custom/asulib_barrio/scss/components/form.scss
@@ -321,3 +321,17 @@ td.field-multiple-drag {
 .paragraphs-subform .form-group {
   margin-bottom: 0;
 }
+
+.webform-submission-self-deposit-form div.progress-step .progress-marker::before {
+  background-color: inherit !important;
+}
+
+.webform-submission-self-deposit-form div.progress-step button {
+  position: relative;
+  top: 1.7rem;
+  z-index: 200;
+}
+
+.webform-submission-self-deposit-form div.progress-step button:not(.btn-maroon) {
+  background-color: white;
+}

--- a/web/themes/custom/asulib_barrio/scss/components/form.scss
+++ b/web/themes/custom/asulib_barrio/scss/components/form.scss
@@ -335,3 +335,12 @@ td.field-multiple-drag {
 .webform-submission-self-deposit-form div.progress-step button:not(.btn-maroon) {
   background-color: white;
 }
+
+.webform-submission-self-deposit-form td input.image-button {
+  border: solid 1px #d0d0d0;
+  opacity: 1;
+}
+
+.webform-submission-self-deposit-form td input.image-button:hover {
+  border: solid 1px #d0d0d0;
+}

--- a/web/themes/custom/asulib_barrio/scss/components/form.scss
+++ b/web/themes/custom/asulib_barrio/scss/components/form.scss
@@ -322,8 +322,10 @@ td.field-multiple-drag {
   margin-bottom: 0;
 }
 
-.webform-submission-self-deposit-form div.progress-step .progress-marker::before {
-  background-color: inherit !important;
+.webform-submission-self-deposit-form div.progress-step {
+  .progress-marker::after, .progress-marker::before {
+    background-color: #747474 !important;
+  }
 }
 
 .webform-submission-self-deposit-form div.progress-step button {

--- a/web/themes/custom/asulib_barrio/scss/components/table.scss
+++ b/web/themes/custom/asulib_barrio/scss/components/table.scss
@@ -25,3 +25,11 @@ span.page-link {
 .webform-submission-self-deposit-form .table-striped tbody tr:nth-of-type(odd) {
     background-color: #e8e8e8;
 }
+
+.webform-submission-self-deposit-form .table-striped tbody tr:nth-of-type(even) input.image-button {
+    background-color: #e8e8e8;
+}
+
+.webform-submission-self-deposit-form .table-striped tbody tr:nth-of-type(odd) input.image-button {
+    background-color: white;
+}

--- a/web/themes/custom/asulib_barrio/scss/components/table.scss
+++ b/web/themes/custom/asulib_barrio/scss/components/table.scss
@@ -21,3 +21,7 @@ span.page-link {
     padding-left: .75rem;
     padding-right: .75rem;
 }
+
+.webform-submission-self-deposit-form .table-striped tbody tr:nth-of-type(odd) {
+    background-color: #e8e8e8;
+}

--- a/web/themes/custom/asulib_barrio/templates/form/webform-progress-tracker--self-deposit.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/form/webform-progress-tracker--self-deposit.html.twig
@@ -1,0 +1,54 @@
+{#
+/**
+ * @file
+ * Default theme implementation for webform wizard progress tracker.
+ *
+ * Available variables:
+ * - webform: A webform.
+ * - pages: Associative array of wizard pages.
+ * - progress: Array of wizard progress containing page titles.
+ * - current_page: Current wizard page key.
+ * - current_index: The current wizard page index.
+ * - max_pages: Maximum number of pages that progress text should be displayed on.
+ *
+ * @see template_preprocess_webform_progress_bar()
+ * @see https://www.w3.org/WAI/tutorials/forms/multi-page/
+ *
+ * @ingroup themeable
+ */
+#}
+{{ attach_library('webform/webform.progress.tracker') }}
+
+<div class="webform-progress-tracker progress-tracker progress-tracker--center" data-webform-progress-steps>
+  {% for index, page in progress %}
+    {% set is_completed = index < current_index %}
+    {% set is_active = index == current_index %}
+    {%
+      set classes = [
+        'progress-step',
+        is_completed ? 'is-complete',
+        is_active ? 'is-active',
+      ]
+    %}
+    {%
+      set attributes = create_attribute()
+        .setAttribute('data-webform-' ~ page.type, page.name)
+        .setAttribute('title', page.title)
+        .setAttribute('class', '')
+        .addClass(classes)
+    %}
+    
+    <div{{ attributes }}>
+      <button type="button" class="btn btn-circle {% if is_active or is_completed %}{{ is_active ? 'btn-maroon' : 'btn-gray' }}{% endif %}">{{ index + 1 }}</button>
+      <div class="progress-marker" data-webform-progress-step data-webform-progress-link></div>
+      {% if progress|length < max_pages %}
+        <div class="progress-text">
+          <div class="progress-title" data-webform-progress-link>
+            <span class="visually-hidden" data-webform-progress-state>{% if is_active or is_completed %}{{ is_active ? 'Current'|t : 'Completed'|t }}{% endif %}</span>
+            {{ page.title }}
+          </div>
+        </div>
+      {% endif %}
+    </div>
+  {% endfor %}
+</div>


### PR DESCRIPTION
This branch contains only a theme override for the self deposit "progress-tracker" twig and some minor CSS to adjust how those buttons look -- as well as to control the colors and look of the buttons that appear in any repeatable row such as Contributors so that the row and button color will contrast -- and use the colors from our theme's gray for the gray row / gray button.

To test / review, just pull in the branch and clear all caches -- and navigate to local "Share Your Work" page http://localhost:8000/share. From the first page, you can review the look of the progress tracker buttons and the bar background color (by the div .progress-marker::before / .progress-marker::after). The second change requires that the progress has taken the user to the second page -- there, the Contributors (among other fields) will exhibit the alternating row colors and buttons that use the contrasting opposite color (our grey or white).

Let me know if you have any questions.