### PR TITLE
Sidebar goes below content under md sizes

### DIFF
--- a/web/themes/custom/asulib_barrio/asulib_barrio.theme
+++ b/web/themes/custom/asulib_barrio/asulib_barrio.theme
@@ -238,6 +238,10 @@ function asulib_barrio_preprocess_user(&$variables) {
  */
 function asulib_barrio_preprocess_page(&$variables) {
   $variables['site_name'] = \Drupal::config('system.site')->get('name');
+  $variables['content_attributes']['class'][] = 'order-1';
+  $variables['content_attributes']['class'][] = 'order-md-12';
+  $variables['sidebar_first_attributes']['class'][] = 'order-md-1';
+  $variables['sidebar_first_attributes']['class'][] = 'order-12';
 }
 
 /**


### PR DESCRIPTION
This change simply adds two classes to the main and sidebar-first div each so that the order is changed under md sizes which makes the sidebar first only as long as the screen is wide enough. Below that width, the sidebar goes below the main content.

There is no config change for this and since this is page_preprocess hook code, it should immediately take effect on any page -- to test, simply change the browser width or use the inspect "toggle device toolbar" to select mobile screen sizes.