### PR TITLE
Hotfix - admin toolbox "Bulk edit items" link ONLY for logged in users

### DIFF
--- a/web/modules/custom/asu_admin_toolbox/src/Plugin/Block/AdminToolboxBlock.php
+++ b/web/modules/custom/asu_admin_toolbox/src/Plugin/Block/AdminToolboxBlock.php
@@ -290,7 +290,7 @@ class AdminToolboxBlock extends BlockBase implements ContainerFactoryPluginInter
       }
     }
     // Solr reindex / Bulk edit collection items link.
-    if ($is_collection || $is_asu_repository_item && ($user_is_admin_or_metadata_manager)) {
+    if (($is_collection || $is_asu_repository_item) && ($user_is_admin_or_metadata_manager)) {
       // Two different possibilities here -- if single item, redirect to Solr
       // reindexing page, else a collection would go through Bulk Edit form.
       if ($is_collection) {


### PR DESCRIPTION
There was a flaw in the logic for this link that allowed it to show for collection pages regardless of whether or not the user was Administrator or "Metadata manager"... The single commit fixes the logic in if block to prevent showing to non-logged in users on collection pages.

Simply pull the branch and reload any collection page while not logged in and see that the Admin toolbox and the "Bulk edit items" link are both gone.