### PR TITLE
Seo hreflang

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -89,6 +89,7 @@
         "drupal/google_analytics": "^3.1",
         "drupal/group": "^1.3",
         "drupal/honeypot": "^2.0",
+        "drupal/hreflang": "^1.4",
         "drupal/inline_entity_form": "^1.0@RC",
         "drupal/jquery_ui_slider": "^1.1",
         "drupal/jquery_ui_touch_punch": "^1.0",

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -88,6 +88,7 @@ module:
   help: 0
   history: 0
   honeypot: 0
+  hreflang: 0
   image: 0
   inline_entity_form: 0
   islandora: 0

--- a/web/modules/custom/asu_item_extras/src/Plugin/Block/ASUSearchItemIsPartOf.php
+++ b/web/modules/custom/asu_item_extras/src/Plugin/Block/ASUSearchItemIsPartOf.php
@@ -92,10 +92,10 @@ class ASUSearchItemIsPartOf extends BlockBase implements ContainerFactoryPluginI
       $parent_node_id = $block_config['parent_node_id'];
       $first_title_view = $para->view(['type' => 'complex_title_formatter']);
       $parent_title = $this->renderer->render($first_title_view);
-      $parent_url = Url::fromRoute('entity.node.canonical', ['node' => $parent_node_id], ['absolute' => TRUE]);
-      $link = Link::fromTextAndUrl($parent_title, $parent_url)->toRenderable();
-      $rendered_link = render($link);
-      $output = 'Part of ' . $rendered_link;
+      $parent_entity = $this->entityTypeManager->getStorage('node')->load($parent_node_id);
+      $link = $parent_entity->toLink();
+      $link->setText($parent_title);
+      $output = 'Part of ' . $link->toString();
     }
     return [
       '#markup' => $output,

--- a/web/modules/custom/asu_search/asu_search.module
+++ b/web/modules/custom/asu_search/asu_search.module
@@ -74,7 +74,8 @@ function asu_search_preprocess_node(&$variables) {
           $date_formatter->formatTimeDiffSince($variables['node']->getChangedTime(), ['granularity' => 2, 'return_as_object' => TRUE])->toRenderable();
       }
       if ($variables['node']->get('field_language')) {
-        $variables['langcode'] = $variables['node']->get('field_language')->entity->get('langcode')->value;
+        $variables['langcode'] = (!is_null($variables['node']->get('field_language')->entity)) ?
+           $variables['node']->get('field_language')->entity->get('langcode')->value : "";
       }
       if ($variables['node']->get('field_model') != NULL && count($variables['node']->get('field_model')) > 0) {
         $model = $variables['node']->get('field_model')->referencedEntities()[0]->getName();

--- a/web/modules/custom/asu_search/asu_search.module
+++ b/web/modules/custom/asu_search/asu_search.module
@@ -73,10 +73,6 @@ function asu_search_preprocess_node(&$variables) {
         $variables['changed_ago'] =
           $date_formatter->formatTimeDiffSince($variables['node']->getChangedTime(), ['granularity' => 2, 'return_as_object' => TRUE])->toRenderable();
       }
-      if ($variables['node']->get('field_language')) {
-        $variables['langcode'] = (!is_null($variables['node']->get('field_language')->entity)) ?
-           $variables['node']->get('field_language')->entity->get('langcode')->value : "";
-      }
       if ($variables['node']->get('field_model') != NULL && count($variables['node']->get('field_model')) > 0) {
         $model = $variables['node']->get('field_model')->referencedEntities()[0]->getName();
         if ($model == "Complex Object") {
@@ -95,6 +91,14 @@ function asu_search_preprocess_node(&$variables) {
             }
           }
         }
+      }
+    }
+    $allow_asu_models = ["asu_audio", "asu_complex_object", "asu_document", "asu_image", "asu_video"];
+    if ((!(array_search($variables['view_mode'], $allow_display_modes) === FALSE)) ||
+      (!(array_search($variables['view_mode'], $allow_asu_models) === FALSE))) {
+      if ($variables['node']->get('field_language')) {
+        $variables['langcode'] = (!is_null($variables['node']->get('field_language')->entity)) ?
+           $variables['node']->get('field_language')->entity->get('langcode')->value : "";
       }
     }
     if ($variables['view_mode'] == 'asu_complex_object') {

--- a/web/modules/custom/asu_search/asu_search.module
+++ b/web/modules/custom/asu_search/asu_search.module
@@ -65,12 +65,16 @@ function asu_search_preprocess_node(&$variables) {
   if ($variables['node'] && $variables['node']->getType() == 'asu_repository_item') {
     $asu_utils = \Drupal::service('asu_utils');
     $variables['is_published'] = $asu_utils->isNodePublished($variables['node']);
+    
     $allow_display_modes = ["search_result", "collection_browse_teaser", "recent_item_teaser", "recent_item_teaser_prism", "full_metadata"];
     if (!(array_search($variables['view_mode'], $allow_display_modes) === FALSE)) {
       if ($variables['view_mode'] == "recent_item_teaser" || $variables['view_mode'] == "full_metadata") {
         $date_formatter = \Drupal::service('date.formatter');
         $variables['changed_ago'] =
           $date_formatter->formatTimeDiffSince($variables['node']->getChangedTime(), ['granularity' => 2, 'return_as_object' => TRUE])->toRenderable();
+      }
+      if ($variables['node']->get('field_language')) {
+        $variables['langcode'] = $variables['node']->get('field_language')->entity->get('langcode')->value;
       }
       if ($variables['node']->get('field_model') != NULL && count($variables['node']->get('field_model')) > 0) {
         $model = $variables['node']->get('field_model')->referencedEntities()[0]->getName();

--- a/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--asu-audio.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--asu-audio.html.twig
@@ -79,7 +79,7 @@
     {{ title_prefix }}
     {% if label and not page %}
       <h2{{title_attributes.addClass('node__title')}}>
-        <a href="{{ url }}" rel="bookmark">{{ label }}</a>
+        <a href="{{ url }}" rel="bookmark"{% if langcode is not empty %} hreflang="{{ langcode }}"{% endif %}>{{ label }}</a>
       </h2>
     {% endif %}
     {{ title_suffix }}
@@ -170,7 +170,7 @@
       <div>
         <p>
           <strong>
-            <a class="icon-link" href="{{ url }}/metadata"><i class="fa fa-lg fa-list-ul"></i><span>{{ 'View full metadata'|t }}</span></a>
+            <a class="icon-link" href="{{ url }}/metadata"{% if langcode is not empty %} hreflang="{{ langcode }}"{% endif %}><i class="fa fa-lg fa-list-ul"></i><span>{{ 'View full metadata'|t }}</span></a>
           </strong>
         </p>
       </div>

--- a/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--asu-complex-object.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--asu-complex-object.html.twig
@@ -79,7 +79,7 @@
     {{ title_prefix }}
     {% if label and not page %}
       <h2{{ title_attributes.addClass('node__title') }}>
-        <a href="{{ url }}" rel="bookmark">{{ label }}</a>
+        <a href="{{ url }}" rel="bookmark"{% if langcode is not empty %} hreflang="{{ langcode }}"{% endif %}>{{ label }}</a>
       </h2>
     {% endif %}
     {{ title_suffix }}
@@ -170,7 +170,7 @@
       <div>
         <p>
           <strong>
-            <a class="icon-link" href="{{ url }}/metadata">
+            <a class="icon-link" href="{{ url }}/metadata"{% if langcode is not empty %} hreflang="{{ langcode }}"{% endif %}>
               <i class="fa fa-lg fa-list-ul"></i>
               <span>{{ 'View full metadata'|t }}</span>
             </a>

--- a/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--asu-document.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--asu-document.html.twig
@@ -79,7 +79,7 @@
     {{ title_prefix }}
     {% if label and not page %}
       <h2{{ title_attributes.addClass('node__title') }}>
-        <a href="{{ url }}" rel="bookmark">{{ label }}</a>
+        <a href="{{ url }}" rel="bookmark"{% if langcode is not empty %} hreflang="{{ langcode }}"{% endif %}>{{ label }}</a>
       </h2>
     {% endif %}
     {{ title_suffix }}
@@ -99,7 +99,7 @@
     <div class="content-section row">
       <div class="col-md-5 file-container">
         {% if of_access %}
-          <a href="{{ url }}/view" class="image-link">{{ content.display_media_thumbnail }}</a>
+          <a href="{{ url }}/view" class="image-link"{% if langcode is not empty %} hreflang="{{ langcode }}"{% endif %}>{{ content.display_media_thumbnail }}</a>
         {% else %}
           {{ content.display_media_thumbnail }}
         {% endif %}
@@ -166,7 +166,7 @@
       <div>
         <p>
           <strong>
-            <a class="icon-link" href="{{ url }}/metadata"><i class="fa fa-lg fa-list-ul"></i><span>{{ 'View full metadata'|t }}</span></a>
+            <a class="icon-link" href="{{ url }}/metadata"{% if langcode is not empty %} hreflang="{{ langcode }}"{% endif %}><i class="fa fa-lg fa-list-ul"></i><span>{{ 'View full metadata'|t }}</span></a>
           </strong>
         </p>
       </div>

--- a/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--asu-image.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--asu-image.html.twig
@@ -79,7 +79,7 @@
     {{ title_prefix }}
     {% if label and not page %}
       <h2{{ title_attributes.addClass('node__title') }}>
-        <a href="{{ url }}" rel="bookmark">{{ label }}</a>
+        <a href="{{ url }}" rel="bookmark"{% if langcode is not empty %} hreflang="{{ langcode }}"{% endif %}>{{ label }}</a>
       </h2>
     {% endif %}
     {{ title_suffix }}
@@ -99,7 +99,7 @@
     <div class="content-section row">
       <div class="col-md-5 file-container">
         {% if of_access %}
-          <a href="{{ url }}/view" class="image-link">{{ content.display_media_thumbnail }}</a>
+          <a href="{{ url }}/view" class="image-link"{% if langcode is not empty %} hreflang="{{ langcode }}"{% endif %}>{{ content.display_media_thumbnail }}</a>
         {% else %}
           {{ content.display_media_thumbnail }}
         {% endif %}
@@ -166,7 +166,7 @@
       <div>
         <p>
           <strong>
-            <a class="icon-link" href="{{ url }}/metadata"><i class="fa fa-lg fa-list-ul"></i><span>{{ 'View full metadata'|t }}</span></a>
+            <a class="icon-link" href="{{ url }}/metadata"{% if langcode is not empty %} hreflang="{{ langcode }}"{% endif %}><i class="fa fa-lg fa-list-ul"></i><span>{{ 'View full metadata'|t }}</span></a>
           </strong>
         </p>
       </div>

--- a/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--asu-video.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--asu-video.html.twig
@@ -79,7 +79,7 @@
     {{ title_prefix }}
     {% if label and not page %}
       <h2{{title_attributes.addClass('node__title')}}>
-        <a href="{{ url }}" rel="bookmark">{{ label }}</a>
+        <a href="{{ url }}" rel="bookmark"{% if langcode is not empty %} hreflang="{{ langcode }}"{% endif %}>{{ label }}</a>
       </h2>
     {% endif %}
     {{ title_suffix }}
@@ -172,7 +172,7 @@
       <div>
         <p>
           <strong>
-            <a class="icon-link" href="{{ url }}/metadata"><i class="fa fa-lg fa-list-ul"></i><span>{{ 'View full metadata'|t }}</span></a>
+            <a class="icon-link" href="{{ url }}/metadata"{% if langcode is not empty %} hreflang="{{ langcode }}"{% endif %}><i class="fa fa-lg fa-list-ul"></i><span>{{ 'View full metadata'|t }}</span></a>
           </strong>
         </p>
       </div>

--- a/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--collection-browse-teaser.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--collection-browse-teaser.html.twig
@@ -104,7 +104,7 @@
         <div class="card-header">
             <h5{{ title_attributes.addClass('node__title', 'card-title') }}>
                 {% set title = content.field_title[0]|render|trim|slice(0, 40) %}
-                <a href="{{ url }}" rel="bookmark">{{ title|raw }}
+                <a href="{{ url }}" rel="bookmark"{% if langcode is not empty %} hreflang="{{ langcode }}"{% endif %}>{{ title|raw }}
                 {% if content.field_title[0]|render|length > 40 %}
                     ...
                 {% endif %}

--- a/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--complex-object-child-box.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--complex-object-child-box.html.twig
@@ -99,7 +99,7 @@
           {% if label %}
             <h5{{ title_attributes.addClass('node__title') }}>
               {% if not is_published %}<i class="fas fa-ban"></i>&nbsp;{% endif %}
-              <a href="{{ url }}" rel="bookmark">{{ label }}</a>
+              <a href="{{ url }}" rel="bookmark"{% if langcode is not empty %} hreflang="{{ langcode }}"{% endif %}>{{ label }}</a>
             </h5>
           {% endif %}
           {{ title_suffix }}
@@ -113,7 +113,7 @@
             {{ drupal_block('downloads_block', {'child_node_id': node.id, 'origfile': original_file, 'servicefile': service_file}) }}
           </div>
           {% if mod == 'Image' or mod == 'Digital Document' %}
-            <a href="/items/{{ node.id }}/view">Preview</a><br/>
+            <a href="/items/{{ node.id }}/view"{% if langcode is not empty %} hreflang="{{ langcode }}"{% endif %}>Preview</a><br/>
           {% elseif (mod == 'Audio' or mod == 'Video') and (of_access or sf_access) %}
             <a data-toggle="collapse" href="#player{{ node.id }}" role="button" aria-expanded="false" aria-controls="player{{ node.id }}"><i class="far fa-play-circle"></i> Play</a><br/>
             <div id="player{{ node.id }}" class="collapse">

--- a/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--recent-item-teaser-prism.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--recent-item-teaser-prism.html.twig
@@ -113,6 +113,6 @@
 		</h3>
 	</div>
 	<div class="card-body">
-		<a role="button" href="/items/{{ node.id }}" class="stretched-link"></a>
+		<a role="button" href="/items/{{ node.id }}" class="stretched-link"{% if langcode is not empty %} hreflang="{{ langcode }}"{% endif %}></a>
 	</div>
 </div>

--- a/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--recent-item-teaser.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--recent-item-teaser.html.twig
@@ -106,7 +106,7 @@
 		</h3>
 	</div>
 	<div class="card-body">
-        <a role="button" href="/items/{{ node.id }}" class="stretched-link"></a>
+        <a role="button" href="/items/{{ node.id }}" class="stretched-link"{% if langcode is not empty %} hreflang="{{ langcode }}"{% endif %}></a>
 		{%  if changed_ago %}
 			<p class="card-text">{{ changed_ago }}
 				ago</p>

--- a/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--search-result.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--search-result.html.twig
@@ -90,12 +90,12 @@
   <div{{ content_attributes.addClass('node__content', 'clearfix', 'row', 'item-result') }}>
     <div class="col-md-2 thumb-image-border">
       {% if complex_obj_thumb is not empty %}
-        <a href="/items/{{ node.id }}"><img src=" {{ complex_obj_thumb }}"/></a>
+        <a href="/items/{{ node.id }}"{% if langcode is not empty %} hreflang="{{ langcode }}"{% endif %}><img src=" {{ complex_obj_thumb }}"/></a>
       {% elseif drupal_view_result('display_media', 'thumbnail', node.id) is empty %}
         {% set mod = content.field_model[0]|render|trim %}
         {% for k, v in model_icons|filter((v, k) => k == mod) -%}
           <div class="icon-container">
-            <a href="/items/{{ node.id }}"><i class="{{ v }} fa-6x"></i></a>
+            <a href="/items/{{ node.id }}"{% if langcode is not empty %} hreflang="{{ langcode }}"{% endif %}><i class="{{ v }} fa-6x"></i></a>
           </div>
         {% endfor %}
       {% else %}
@@ -104,7 +104,7 @@
     </div>
     <div class="col-md-10">
       <h4>{% if not is_published %}<i class="fa fa-lock"></i>&nbsp;
-          {% endif %}<a href="{{ url }}" rel="bookmark">{{ content.field_title[0] }}</a></h4>
+          {% endif %}<a href="{{ url }}" rel="bookmark"{% if langcode is not empty %} hreflang="{{ langcode }}"{% endif %}>{{ content.field_title[0] }}</a></h4>
       {% if node.field_complex_object_child.value == 1 %}
         {% set parent = node.field_member_of.entity %}
         {% set par_title = parent.field_title[0] %}

--- a/web/themes/custom/asulib_barrio/templates/content/node--collection--full.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/content/node--collection--full.html.twig
@@ -77,7 +77,7 @@
         {{ title_prefix }}
         {% if label and not page %}
             <h2{{ title_attributes.addClass('node__title') }}>
-                <a href="{{ url }}" rel="bookmark">{{ label }}</a>
+                <a href="{{ url }}" rel="bookmark"{% if langcode is not empty %} hreflang="{{ langcode }}"{% endif %}>{{ label }}</a>
             </h2>
         {% endif %}
         {{ title_suffix }}

--- a/web/themes/custom/asulib_barrio/templates/content/node--feature--teaser.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/content/node--feature--teaser.html.twig
@@ -75,9 +75,9 @@
 <article{{ attributes.addClass(classes) }}>
   <div class="container">
     <div class="row">
-      <div class="col-3"><a href="{{node.field_link.0.url}}">{{content.field_feature_image}}</a></div>
+      <div class="col-3"><a href="{{node.field_link.0.url}}"{% if langcode is not empty %} hreflang="{{ langcode }}"{% endif %}>{{content.field_feature_image}}</a></div>
       <div class="col-9">
-        <h4><a href="{{node.field_link.0.url}}">{{label}}</a></h4>
+        <h4><a href="{{node.field_link.0.url}}"{% if langcode is not empty %} hreflang="{{ langcode }}"{% endif %}>{{label}}</a></h4>
         <p>{{content.body}}</p>
         <p>
 		      <a class="btn btn-maroon" href="{{node.field_link.0.url}}" target="_blank">Explore</a>


### PR DESCRIPTION
This feature branch includes the hreflang module that adds hreflang="{content language code}" to most of the links but individual updates to some custom template twig files and custom blocks code needed to be updated as well.

- [ ]  search results title link (site search, collection search, and complex object child search)
- [ ]  "Part of {complex object parent}" links
- [ ]  Latest Items
- [ ]  Recent items (both sites)
- [ ]  Recent collections
- [ ]  Included in this item
- [ ]  ~~breadcrumbs~~ 
- [ ] ~~facets~~

Since breadcrumbs were too tricky to address in a timely manner, I have not included any changes for them. Also, facets seem like they are not the right place to have any language-attribute links... since they are essentially all search links.

In order to review this code, after checking out the branch you will need to run `composer install` followed by `cd web; drush pm-enable hreflang` and then clear all caches (there is no functional config update since it only represents that the hreflang module was installed).

To test, look specifically for the links to contain a `hreflang="en"` for example for content that has a language langcode of "en"... 
for the hreflang module functionality, look for these added link attributes in things like Subjects, Agents, other core places that link to asu_repository_item Items, and any other entities that have a language value... 
for this feature branch's twig updates, inspect the html of the home page (Recent items & collections), individual items, complex object pages (Included in this item block & page), search results pages, and collection pages (Latest items)