### PR TITLE
Collection glossary collection bugfix'd

### DIFF
--- a/config/sync/views.view.collections.yml
+++ b/config/sync/views.view.collections.yml
@@ -1115,7 +1115,7 @@ display:
     position: 1
     display_options:
       display_extenders: {  }
-      path: collections/%
+      path: collections/browse-by/%
       menu:
         type: normal
         title: 'Browse Collections'


### PR DESCRIPTION
changed the glossary route from collections/% to collections/browse-by/% to avoid collection node-id ~ first letter (is a number) possible clash for #495