### PR TITLE
Add hreflang attributes to ./view and download links

### DIFF
--- a/config/sync/core.entity_form_display.taxonomy_term.language.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.language.default.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - field.field.taxonomy_term.language.field_authority_link
+    - field.field.taxonomy_term.language.field_langcode_2digits
     - taxonomy.vocabulary.language
   module:
     - controlled_access_terms
@@ -14,12 +15,12 @@ bundle: language
 mode: default
 content:
   description:
-    type: text_textfield
+    type: text_textarea
     weight: 0
     region: content
     settings:
-      size: 60
       placeholder: ''
+      rows: 5
     third_party_settings: {  }
   field_authority_link:
     weight: 31
@@ -28,6 +29,14 @@ content:
       placeholder_title: ''
     third_party_settings: {  }
     type: authority_link_default
+    region: content
+  field_langcode_2digits:
+    weight: 3
+    settings:
+      size: 2
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
     region: content
   langcode:
     type: language_select
@@ -59,7 +68,7 @@ content:
     third_party_settings: {  }
   translation:
     weight: 10
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
 hidden: {  }

--- a/config/sync/core.entity_view_display.taxonomy_term.language.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.language.default.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - field.field.taxonomy_term.language.field_authority_link
+    - field.field.taxonomy_term.language.field_langcode_2digits
     - taxonomy.vocabulary.language
   module:
     - text
@@ -32,5 +33,6 @@ content:
     region: content
 hidden:
   field_authority_link: true
+  field_langcode_2digits: true
   langcode: true
   search_api_excerpt: true

--- a/config/sync/field.field.taxonomy_term.language.field_langcode_2digits.yml
+++ b/config/sync/field.field.taxonomy_term.language.field_langcode_2digits.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_langcode_2digits
+    - taxonomy.vocabulary.language
+id: taxonomy_term.language.field_langcode_2digits
+field_name: field_langcode_2digits
+entity_type: taxonomy_term
+bundle: language
+label: langcode_2digits
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.taxonomy_term.field_langcode_2digits.yml
+++ b/config/sync/field.storage.taxonomy_term.field_langcode_2digits.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - taxonomy
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: taxonomy_term.field_langcode_2digits
+field_name: field_langcode_2digits
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 2
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/asu_item_extras/src/Plugin/Block/DownloadsBlock.php
+++ b/web/modules/custom/asu_item_extras/src/Plugin/Block/DownloadsBlock.php
@@ -170,13 +170,20 @@ class DownloadsBlock extends BlockBase implements ContainerFactoryPluginInterfac
       $masterfile = NULL;
     }
 
+    $node_language = $node->get('field_language')->entity;
+    $link_hreflang = [];
+    if ($node_language) {
+      if ($node_language->hasField('langcode_2digits') && $node_language->get('langcode_2digits')->value) {
+        $link_hreflang = ['hreflang' => $node_language->get('langcode_2digits')->value];
+      }
+    }
     if ($origfile && $origfile->bundle() <> 'remote_video') {
       $source_field = $media_source_service->getSourceFieldName($origfile->bundle());
       if (!empty($source_field)) {
         $of_file = ($origfile->hasField($source_field) && (is_object($origfile->get($source_field)) && $origfile->get($source_field)->referencedEntities() != NULL) ? $origfile->get($source_field)->referencedEntities()[0] : FALSE);
         if ($of_file) {
           $of_uri = $islandora_utils->getDownloadUrl($of_file);
-          $of_link = Link::fromTextAndUrl($this->t('Original'), Url::fromUri($of_uri, ['attributes' => ['class' => ['dropdown-item'], 'download' => TRUE]]));
+          $of_link = Link::fromTextAndUrl($this->t('Original'), Url::fromUri($of_uri, ['attributes' => array_merge($link_hreflang, ['class' => ['dropdown-item'], 'download' => TRUE])]));
           $file_size = $origfile->get('field_file_size')->value;
           $download_info .= " " . $origfile->get('field_mime_type')->value;
         }
@@ -189,7 +196,7 @@ class DownloadsBlock extends BlockBase implements ContainerFactoryPluginInterfac
         $sf_file = ($servicefile->hasField($source_field) && (is_object($servicefile->get($source_field)) && $servicefile->get($source_field)->referencedEntities() != NULL) ? $servicefile->get($source_field)->referencedEntities()[0] : FALSE);
         if ($sf_file) {
           $sf_uri = $islandora_utils->getDownloadUrl($sf_file);
-          $sf_link = Link::fromTextAndUrl($this->t('Derivative'), Url::fromUri($sf_uri, ['attributes' => ['class' => ['dropdown-item']]]));
+          $sf_link = Link::fromTextAndUrl($this->t('Derivative'), Url::fromUri($sf_uri, ['attributes' => array_merge($link_hreflang, ['class' => ['dropdown-item']])]));
           // $download_info .= $servicefile->get('field_mime_type')->value;
         }
       }
@@ -199,7 +206,7 @@ class DownloadsBlock extends BlockBase implements ContainerFactoryPluginInterfac
       if (!empty($source_field)) {
         $pmf_file = $masterfile->get($source_field)->referencedEntities()[0];
         $pmf_uri = $islandora_utils->getDownloadUrl($pmf_file);
-        $pmf_link = Link::fromTextAndUrl($this->t('Master'), Url::fromUri($pmf_uri, ['attributes' => ['class' => ['dropdown-item']]]));
+        $pmf_link = Link::fromTextAndUrl($this->t('Master'), Url::fromUri($pmf_uri, ['attributes' => array_merge($link_hreflang, ['class' => ['dropdown-item']])]));
         // $download_info .= $masterfile->get('field_mime_type')->value;
       }
     }

--- a/web/modules/custom/asu_item_extras/src/Plugin/Block/DownloadsBlock.php
+++ b/web/modules/custom/asu_item_extras/src/Plugin/Block/DownloadsBlock.php
@@ -173,8 +173,8 @@ class DownloadsBlock extends BlockBase implements ContainerFactoryPluginInterfac
     $node_language = $node->get('field_language')->entity;
     $link_hreflang = [];
     if ($node_language) {
-      if ($node_language->hasField('langcode_2digits') && $node_language->get('langcode_2digits')->value) {
-        $link_hreflang = ['hreflang' => $node_language->get('langcode_2digits')->value];
+      if ($node_language->hasField('field_langcode_2digits') && $node_language->get('field_langcode_2digits')->value) {
+        $link_hreflang = ['hreflang' => $node_language->get('field_langcode_2digits')->value];
       }
     }
     if ($origfile && $origfile->bundle() <> 'remote_video') {

--- a/web/modules/custom/asu_taxonomies/config/install/migrate_plus.migration.languages.yml
+++ b/web/modules/custom/asu_taxonomies/config/install/migrate_plus.migration.languages.yml
@@ -21,6 +21,7 @@ process:
     plugin: skip_on_empty
     source: uri
     method: process
+  field_langcode_2digits: code_2digit
 
 destination:
   plugin: 'entity:taxonomy_term'

--- a/web/modules/custom/asu_taxonomies/migrate/languages.csv
+++ b/web/modules/custom/asu_taxonomies/migrate/languages.csv
@@ -1,81 +1,81 @@
 vid,code,name,uri,code_2digit
-language,aar,Afar,http://id.loc.gov/vocabulary/languages/aar,
-language,abk,Abkhaz,http://id.loc.gov/vocabulary/languages/abk,
+language,aar,Afar,http://id.loc.gov/vocabulary/languages/aar,aa
+language,abk,Abkhaz,http://id.loc.gov/vocabulary/languages/abk,ab
 language,ace,Achinese,http://id.loc.gov/vocabulary/languages/ace,
 language,ach,Acoli,http://id.loc.gov/vocabulary/languages/ach,
 language,ada,Adangme,http://id.loc.gov/vocabulary/languages/ada,
 language,ady,Adygei,http://id.loc.gov/vocabulary/languages/ady,
 language,afa,Afroasiatic (Other),http://id.loc.gov/vocabulary/languages/afa,
 language,afh,Afrihili (Artificial language),http://id.loc.gov/vocabulary/languages/afh,
-language,afr,Afrikaans,http://id.loc.gov/vocabulary/languages/afr,
+language,afr,Afrikaans,http://id.loc.gov/vocabulary/languages/afr,af
 language,ain,Ainu,http://id.loc.gov/vocabulary/languages/ain,
-language,aka,Akan,http://id.loc.gov/vocabulary/languages/aka,
+language,aka,Akan,http://id.loc.gov/vocabulary/languages/aka,ak
 language,akk,Akkadian,http://id.loc.gov/vocabulary/languages/akk,
 language,alb,Albanian,http://id.loc.gov/vocabulary/languages/alb,
 language,ale,Aleut,http://id.loc.gov/vocabulary/languages/ale,
 language,alg,Algonquian (Other),http://id.loc.gov/vocabulary/languages/alg,
 language,alt,Altai,http://id.loc.gov/vocabulary/languages/alt,
-language,amh,Amharic,http://id.loc.gov/vocabulary/languages/amh,
+language,amh,Amharic,http://id.loc.gov/vocabulary/languages/amh,am
 language,ang,"English, Old (ca. 450-1100)",http://id.loc.gov/vocabulary/languages/ang,
 language,anp,Angika,http://id.loc.gov/vocabulary/languages/anp,
 language,apa,Apache languages,http://id.loc.gov/vocabulary/languages/apa,
-language,ara,Arabic,http://id.loc.gov/vocabulary/languages/ara,
+language,ara,Arabic,http://id.loc.gov/vocabulary/languages/ara,ar
 language,arc,Aramaic,http://id.loc.gov/vocabulary/languages/arc,
-language,arg,Aragonese,http://id.loc.gov/vocabulary/languages/arg,
+language,arg,Aragonese,http://id.loc.gov/vocabulary/languages/arg,an
 language,arm,Armenian,http://id.loc.gov/vocabulary/languages/arm,
 language,arn,Mapuche,http://id.loc.gov/vocabulary/languages/arn,
 language,arp,Arapaho,http://id.loc.gov/vocabulary/languages/arp,
 language,art,Artificial (Other),http://id.loc.gov/vocabulary/languages/art,
 language,arw,Arawak,http://id.loc.gov/vocabulary/languages/arw,
-language,asm,Assamese,http://id.loc.gov/vocabulary/languages/asm,
+language,asm,Assamese,http://id.loc.gov/vocabulary/languages/asm,as
 language,ast,Bable,http://id.loc.gov/vocabulary/languages/ast,
 language,ath,Athapascan (Other),http://id.loc.gov/vocabulary/languages/ath,
 language,aus,Australian languages,http://id.loc.gov/vocabulary/languages/aus,
-language,ava,Avaric,http://id.loc.gov/vocabulary/languages/ava,
-language,ave,Avestan,http://id.loc.gov/vocabulary/languages/ave,
+language,ava,Avaric,http://id.loc.gov/vocabulary/languages/ava,av
+language,ave,Avestan,http://id.loc.gov/vocabulary/languages/ave,ae
 language,awa,Awadhi,http://id.loc.gov/vocabulary/languages/awa,
-language,aym,Aymara,http://id.loc.gov/vocabulary/languages/aym,
-language,aze,Azerbaijani,http://id.loc.gov/vocabulary/languages/aze,
+language,aym,Aymara,http://id.loc.gov/vocabulary/languages/aym,ay
+language,aze,Azerbaijani,http://id.loc.gov/vocabulary/languages/aze,az
 language,bad,Banda languages,http://id.loc.gov/vocabulary/languages/bad,
 language,bai,Bamileke languages,http://id.loc.gov/vocabulary/languages/bai,
-language,bak,Bashkir,http://id.loc.gov/vocabulary/languages/bak,
+language,bak,Bashkir,http://id.loc.gov/vocabulary/languages/bak,ba
 language,bal,Baluchi,http://id.loc.gov/vocabulary/languages/bal,
-language,bam,Bambara,http://id.loc.gov/vocabulary/languages/bam,
+language,bam,Bambara,http://id.loc.gov/vocabulary/languages/bam,bm
 language,ban,Balinese,http://id.loc.gov/vocabulary/languages/ban,
 language,baq,Basque,http://id.loc.gov/vocabulary/languages/baq,
 language,bas,Basa,http://id.loc.gov/vocabulary/languages/bas,
 language,bat,Baltic (Other),http://id.loc.gov/vocabulary/languages/bat,
 language,bej,Beja,http://id.loc.gov/vocabulary/languages/bej,
-language,bel,Belarusian,http://id.loc.gov/vocabulary/languages/bel,
+language,bel,Belarusian,http://id.loc.gov/vocabulary/languages/bel,be
 language,bem,Bemba,http://id.loc.gov/vocabulary/languages/bem,
-language,ben,Bengali,http://id.loc.gov/vocabulary/languages/ben,
+language,ben,Bengali,http://id.loc.gov/vocabulary/languages/ben,bn
 language,ber,Berber (Other),http://id.loc.gov/vocabulary/languages/ber,
 language,bho,Bhojpuri,http://id.loc.gov/vocabulary/languages/bho,
 language,bih,Bihari (Other),http://id.loc.gov/vocabulary/languages/bih,
 language,bik,Bikol,http://id.loc.gov/vocabulary/languages/bik,
 language,bin,Edo,http://id.loc.gov/vocabulary/languages/bin,
-language,bis,Bislama,http://id.loc.gov/vocabulary/languages/bis,
+language,bis,Bislama,http://id.loc.gov/vocabulary/languages/bis,bi
 language,bla,Siksika,http://id.loc.gov/vocabulary/languages/bla,
 language,bnt,Bantu (Other),http://id.loc.gov/vocabulary/languages/bnt,
-language,bos,Bosnian,http://id.loc.gov/vocabulary/languages/bos,
+language,bos,Bosnian,http://id.loc.gov/vocabulary/languages/bos,bs
 language,bra,Braj,http://id.loc.gov/vocabulary/languages/bra,
-language,bre,Breton,http://id.loc.gov/vocabulary/languages/bre,
+language,bre,Breton,http://id.loc.gov/vocabulary/languages/bre,br
 language,btk,Batak,http://id.loc.gov/vocabulary/languages/btk,
 language,bua,Buriat,http://id.loc.gov/vocabulary/languages/bua,
 language,bug,Bugis,http://id.loc.gov/vocabulary/languages/bug,
-language,bul,Bulgarian,http://id.loc.gov/vocabulary/languages/bul,
+language,bul,Bulgarian,http://id.loc.gov/vocabulary/languages/bul,bg
 language,bur,Burmese,http://id.loc.gov/vocabulary/languages/bur,
 language,byn,Bilin,http://id.loc.gov/vocabulary/languages/byn,
 language,cad,Caddo,http://id.loc.gov/vocabulary/languages/cad,
 language,cai,Central American Indian (Other),http://id.loc.gov/vocabulary/languages/cai,
 language,car,Carib,http://id.loc.gov/vocabulary/languages/car,
-language,cat,Catalan,http://id.loc.gov/vocabulary/languages/cat,
+language,cat,Catalan,http://id.loc.gov/vocabulary/languages/cat,ca
 language,cau,Caucasian (Other),http://id.loc.gov/vocabulary/languages/cau,
 language,ceb,Cebuano,http://id.loc.gov/vocabulary/languages/ceb,
 language,cel,Celtic (Other),http://id.loc.gov/vocabulary/languages/cel,
-language,cha,Chamorro,http://id.loc.gov/vocabulary/languages/cha,
+language,cha,Chamorro,http://id.loc.gov/vocabulary/languages/cha,ch
 language,chb,Chibcha,http://id.loc.gov/vocabulary/languages/chb,
-language,che,Chechen,http://id.loc.gov/vocabulary/languages/che,
+language,che,Chechen,http://id.loc.gov/vocabulary/languages/che,ce
 language,chg,Chagatai,http://id.loc.gov/vocabulary/languages/chg,
 language,chi,Chinese,http://id.loc.gov/vocabulary/languages/chi,
 language,chk,Chuukese,http://id.loc.gov/vocabulary/languages/chk,
@@ -84,32 +84,32 @@ language,chn,Chinook jargon,http://id.loc.gov/vocabulary/languages/chn,
 language,cho,Choctaw,http://id.loc.gov/vocabulary/languages/cho,
 language,chp,Chipewyan,http://id.loc.gov/vocabulary/languages/chp,
 language,chr,Cherokee,http://id.loc.gov/vocabulary/languages/chr,
-language,chu,Church Slavic,http://id.loc.gov/vocabulary/languages/chu,
-language,chv,Chuvash,http://id.loc.gov/vocabulary/languages/chv,
+language,chu,Church Slavic,http://id.loc.gov/vocabulary/languages/chu,cu
+language,chv,Chuvash,http://id.loc.gov/vocabulary/languages/chv,cv
 language,chy,Cheyenne,http://id.loc.gov/vocabulary/languages/chy,
 language,cmc,Chamic languages,http://id.loc.gov/vocabulary/languages/cmc,
 language,cnr,Montenegrin,http://id.loc.gov/vocabulary/languages/cnr,
 language,cop,Coptic,http://id.loc.gov/vocabulary/languages/cop,
-language,cor,Cornish,http://id.loc.gov/vocabulary/languages/cor,
-language,cos,Corsican,http://id.loc.gov/vocabulary/languages/cos,
+language,cor,Cornish,http://id.loc.gov/vocabulary/languages/cor,kw
+language,cos,Corsican,http://id.loc.gov/vocabulary/languages/cos,co
 language,cpe,"Creoles and Pidgins, English-based (Other)",http://id.loc.gov/vocabulary/languages/cpe,
 language,cpf,"Creoles and Pidgins, French-based (Other)",http://id.loc.gov/vocabulary/languages/cpf,
 language,cpp,"Creoles and Pidgins, Portuguese-based (Other)",http://id.loc.gov/vocabulary/languages/cpp,
-language,cre,Cree,http://id.loc.gov/vocabulary/languages/cre,
+language,cre,Cree,http://id.loc.gov/vocabulary/languages/cre,cr
 language,crh,Crimean Tatar,http://id.loc.gov/vocabulary/languages/crh,
 language,crp,Creoles and Pidgins (Other),http://id.loc.gov/vocabulary/languages/crp,
 language,csb,Kashubian,http://id.loc.gov/vocabulary/languages/csb,
 language,cus,Cushitic (Other),http://id.loc.gov/vocabulary/languages/cus,
 language,cze,Czech,http://id.loc.gov/vocabulary/languages/cze,
 language,dak,Dakota,http://id.loc.gov/vocabulary/languages/dak,
-language,dan,Danish,http://id.loc.gov/vocabulary/languages/dan,
+language,dan,Danish,http://id.loc.gov/vocabulary/languages/dan,da
 language,dar,Dargwa,http://id.loc.gov/vocabulary/languages/dar,
 language,day,Dayak,http://id.loc.gov/vocabulary/languages/day,
 language,del,Delaware,http://id.loc.gov/vocabulary/languages/del,
 language,den,Slavey,http://id.loc.gov/vocabulary/languages/den,
 language,dgr,Dogrib,http://id.loc.gov/vocabulary/languages/dgr,
 language,din,Dinka,http://id.loc.gov/vocabulary/languages/din,
-language,div,Divehi,http://id.loc.gov/vocabulary/languages/div,
+language,div,Divehi,http://id.loc.gov/vocabulary/languages/div,dv
 language,doi,Dogri,http://id.loc.gov/vocabulary/languages/doi,
 language,dra,Dravidian (Other),http://id.loc.gov/vocabulary/languages/dra,
 language,dsb,Lower Sorbian,http://id.loc.gov/vocabulary/languages/dsb,
@@ -117,32 +117,32 @@ language,dua,Duala,http://id.loc.gov/vocabulary/languages/dua,
 language,dum,"Dutch, Middle (ca. 1050-1350)",http://id.loc.gov/vocabulary/languages/dum,
 language,dut,Dutch,http://id.loc.gov/vocabulary/languages/dut,
 language,dyu,Dyula,http://id.loc.gov/vocabulary/languages/dyu,
-language,dzo,Dzongkha,http://id.loc.gov/vocabulary/languages/dzo,
+language,dzo,Dzongkha,http://id.loc.gov/vocabulary/languages/dzo,dz
 language,efi,Efik,http://id.loc.gov/vocabulary/languages/efi,
 language,egy,Egyptian,http://id.loc.gov/vocabulary/languages/egy,
 language,eka,Ekajuk,http://id.loc.gov/vocabulary/languages/eka,
 language,elx,Elamite,http://id.loc.gov/vocabulary/languages/elx,
 language,eng,English,http://id.loc.gov/vocabulary/languages/eng,en
-language,enm,"English, Middle (1100-1500)",http://id.loc.gov/vocabulary/languages/enm,en
-language,epo,Esperanto,http://id.loc.gov/vocabulary/languages/epo,
-language,est,Estonian,http://id.loc.gov/vocabulary/languages/est,
-language,ewe,Ewe,http://id.loc.gov/vocabulary/languages/ewe,
+language,enm,"English, Middle (1100-1500)",http://id.loc.gov/vocabulary/languages/enm,
+language,epo,Esperanto,http://id.loc.gov/vocabulary/languages/epo,eo
+language,est,Estonian,http://id.loc.gov/vocabulary/languages/est,et
+language,ewe,Ewe,http://id.loc.gov/vocabulary/languages/ewe,ee
 language,ewo,Ewondo,http://id.loc.gov/vocabulary/languages/ewo,
 language,fan,Fang,http://id.loc.gov/vocabulary/languages/fan,
-language,fao,Faroese,http://id.loc.gov/vocabulary/languages/fao,
+language,fao,Faroese,http://id.loc.gov/vocabulary/languages/fao,fo
 language,fat,Fanti,http://id.loc.gov/vocabulary/languages/fat,
-language,fij,Fijian,http://id.loc.gov/vocabulary/languages/fij,
+language,fij,Fijian,http://id.loc.gov/vocabulary/languages/fij,fj
 language,fil,Filipino,http://id.loc.gov/vocabulary/languages/fil,
-language,fin,Finnish,http://id.loc.gov/vocabulary/languages/fin,
+language,fin,Finnish,http://id.loc.gov/vocabulary/languages/fin,fi
 language,fiu,Finno-Ugrian (Other),http://id.loc.gov/vocabulary/languages/fiu,
 language,fon,Fon,http://id.loc.gov/vocabulary/languages/fon,
-language,fre,French,http://id.loc.gov/vocabulary/languages/fre,fr
-language,frm,"French, Middle (ca. 1300-1600)",http://id.loc.gov/vocabulary/languages/frm,fr
-language,fro,"French, Old (ca. 842-1300)",http://id.loc.gov/vocabulary/languages/fro,fr
+language,fre,French,http://id.loc.gov/vocabulary/languages/fre,
+language,frm,"French, Middle (ca. 1300-1600)",http://id.loc.gov/vocabulary/languages/frm,
+language,fro,"French, Old (ca. 842-1300)",http://id.loc.gov/vocabulary/languages/fro,
 language,frr,North Frisian,http://id.loc.gov/vocabulary/languages/frr,
 language,frs,East Frisian,http://id.loc.gov/vocabulary/languages/frs,
-language,fry,Frisian,http://id.loc.gov/vocabulary/languages/fry,
-language,ful,Fula,http://id.loc.gov/vocabulary/languages/ful,
+language,fry,Frisian,http://id.loc.gov/vocabulary/languages/fry,fy
+language,ful,Fula,http://id.loc.gov/vocabulary/languages/ful,ff
 language,fur,Friulian,http://id.loc.gov/vocabulary/languages/fur,
 language,gaa,Gã,http://id.loc.gov/vocabulary/languages/gaa,
 language,gay,Gayo,http://id.loc.gov/vocabulary/languages/gay,
@@ -152,10 +152,10 @@ language,geo,Georgian,http://id.loc.gov/vocabulary/languages/geo,
 language,ger,German,http://id.loc.gov/vocabulary/languages/ger,
 language,gez,Ethiopic,http://id.loc.gov/vocabulary/languages/gez,
 language,gil,Gilbertese,http://id.loc.gov/vocabulary/languages/gil,
-language,gla,Scottish Gaelic,http://id.loc.gov/vocabulary/languages/gla,
-language,gle,Irish,http://id.loc.gov/vocabulary/languages/gle,
-language,glg,Galician,http://id.loc.gov/vocabulary/languages/glg,
-language,glv,Manx,http://id.loc.gov/vocabulary/languages/glv,
+language,gla,Scottish Gaelic,http://id.loc.gov/vocabulary/languages/gla,gd
+language,gle,Irish,http://id.loc.gov/vocabulary/languages/gle,ga
+language,glg,Galician,http://id.loc.gov/vocabulary/languages/glg,gl
+language,glv,Manx,http://id.loc.gov/vocabulary/languages/glv,gv
 language,gmh,"German, Middle High (ca. 1050-1500)",http://id.loc.gov/vocabulary/languages/gmh,
 language,goh,"German, Old High (ca. 750-1050)",http://id.loc.gov/vocabulary/languages/goh,
 language,gon,Gondi,http://id.loc.gov/vocabulary/languages/gon,
@@ -164,99 +164,99 @@ language,got,Gothic,http://id.loc.gov/vocabulary/languages/got,
 language,grb,Grebo,http://id.loc.gov/vocabulary/languages/grb,
 language,grc,"Greek, Ancient (to 1453)",http://id.loc.gov/vocabulary/languages/grc,
 language,gre,"Greek, Modern (1453-)",http://id.loc.gov/vocabulary/languages/gre,
-language,grn,Guarani,http://id.loc.gov/vocabulary/languages/grn,
+language,grn,Guarani,http://id.loc.gov/vocabulary/languages/grn,gn
 language,gsw,Swiss German,http://id.loc.gov/vocabulary/languages/gsw,
-language,guj,Gujarati,http://id.loc.gov/vocabulary/languages/guj,
+language,guj,Gujarati,http://id.loc.gov/vocabulary/languages/guj,gu
 language,gwi,Gwich'in,http://id.loc.gov/vocabulary/languages/gwi,
 language,hai,Haida,http://id.loc.gov/vocabulary/languages/hai,
-language,hat,Haitian French Creole,http://id.loc.gov/vocabulary/languages/hat,
-language,hau,Hausa,http://id.loc.gov/vocabulary/languages/hau,
+language,hat,Haitian French Creole,http://id.loc.gov/vocabulary/languages/hat,ht
+language,hau,Hausa,http://id.loc.gov/vocabulary/languages/hau,ha
 language,haw,Hawaiian,http://id.loc.gov/vocabulary/languages/haw,
-language,heb,Hebrew,http://id.loc.gov/vocabulary/languages/heb,
-language,her,Herero,http://id.loc.gov/vocabulary/languages/her,
+language,heb,Hebrew,http://id.loc.gov/vocabulary/languages/heb,he
+language,her,Herero,http://id.loc.gov/vocabulary/languages/her,hz
 language,hil,Hiligaynon,http://id.loc.gov/vocabulary/languages/hil,
 language,him,Western Pahari languages,http://id.loc.gov/vocabulary/languages/him,
-language,hin,Hindi,http://id.loc.gov/vocabulary/languages/hin,
+language,hin,Hindi,http://id.loc.gov/vocabulary/languages/hin,hi
 language,hit,Hittite,http://id.loc.gov/vocabulary/languages/hit,
 language,hmn,Hmong,http://id.loc.gov/vocabulary/languages/hmn,
-language,hmo,Hiri Motu,http://id.loc.gov/vocabulary/languages/hmo,
-language,hrv,Croatian,http://id.loc.gov/vocabulary/languages/hrv,
+language,hmo,Hiri Motu,http://id.loc.gov/vocabulary/languages/hmo,ho
+language,hrv,Croatian,http://id.loc.gov/vocabulary/languages/hrv,hr
 language,hsb,Upper Sorbian,http://id.loc.gov/vocabulary/languages/hsb,
-language,hun,Hungarian,http://id.loc.gov/vocabulary/languages/hun,
+language,hun,Hungarian,http://id.loc.gov/vocabulary/languages/hun,hu
 language,hup,Hupa,http://id.loc.gov/vocabulary/languages/hup,
 language,iba,Iban,http://id.loc.gov/vocabulary/languages/iba,
-language,ibo,Igbo,http://id.loc.gov/vocabulary/languages/ibo,
+language,ibo,Igbo,http://id.loc.gov/vocabulary/languages/ibo,ig
 language,ice,Icelandic,http://id.loc.gov/vocabulary/languages/ice,
-language,ido,Ido,http://id.loc.gov/vocabulary/languages/ido,
-language,iii,Sichuan Yi,http://id.loc.gov/vocabulary/languages/iii,
+language,ido,Ido,http://id.loc.gov/vocabulary/languages/ido,io
+language,iii,Sichuan Yi,http://id.loc.gov/vocabulary/languages/iii,ii
 language,ijo,Ijo,http://id.loc.gov/vocabulary/languages/ijo,
-language,iku,Inuktitut,http://id.loc.gov/vocabulary/languages/iku,
-language,ile,Interlingue,http://id.loc.gov/vocabulary/languages/ile,
+language,iku,Inuktitut,http://id.loc.gov/vocabulary/languages/iku,iu
+language,ile,Interlingue,http://id.loc.gov/vocabulary/languages/ile,ie
 language,ilo,Iloko,http://id.loc.gov/vocabulary/languages/ilo,
-language,ina,Interlingua (International Auxiliary Language Association),http://id.loc.gov/vocabulary/languages/ina,
+language,ina,Interlingua (International Auxiliary Language Association),http://id.loc.gov/vocabulary/languages/ina,ia
 language,inc,Indic (Other),http://id.loc.gov/vocabulary/languages/inc,
-language,ind,Indonesian,http://id.loc.gov/vocabulary/languages/ind,
+language,ind,Indonesian,http://id.loc.gov/vocabulary/languages/ind,id
 language,ine,Indo-European (Other),http://id.loc.gov/vocabulary/languages/ine,
 language,inh,Ingush,http://id.loc.gov/vocabulary/languages/inh,
-language,ipk,Inupiaq,http://id.loc.gov/vocabulary/languages/ipk,
+language,ipk,Inupiaq,http://id.loc.gov/vocabulary/languages/ipk,ik
 language,ira,Iranian (Other),http://id.loc.gov/vocabulary/languages/ira,
 language,iro,Iroquoian (Other),http://id.loc.gov/vocabulary/languages/iro,
-language,ita,Italian,http://id.loc.gov/vocabulary/languages/ita,
-language,jav,Javanese,http://id.loc.gov/vocabulary/languages/jav,
+language,ita,Italian,http://id.loc.gov/vocabulary/languages/ita,it
+language,jav,Javanese,http://id.loc.gov/vocabulary/languages/jav,jv
 language,jbo,Lojban (Artificial language),http://id.loc.gov/vocabulary/languages/jbo,
-language,jpn,Japanese,http://id.loc.gov/vocabulary/languages/jpn,
+language,jpn,Japanese,http://id.loc.gov/vocabulary/languages/jpn,ja
 language,jpr,Judeo-Persian,http://id.loc.gov/vocabulary/languages/jpr,
 language,jrb,Judeo-Arabic,http://id.loc.gov/vocabulary/languages/jrb,
 language,kaa,Kara-Kalpak,http://id.loc.gov/vocabulary/languages/kaa,
 language,kab,Kabyle,http://id.loc.gov/vocabulary/languages/kab,
 language,kac,Kachin,http://id.loc.gov/vocabulary/languages/kac,
-language,kal,Kalâtdlisut,http://id.loc.gov/vocabulary/languages/kal,
+language,kal,Kalâtdlisut,http://id.loc.gov/vocabulary/languages/kal,kl
 language,kam,Kamba,http://id.loc.gov/vocabulary/languages/kam,
-language,kan,Kannada,http://id.loc.gov/vocabulary/languages/kan,
+language,kan,Kannada,http://id.loc.gov/vocabulary/languages/kan,kn
 language,kar,Karen languages,http://id.loc.gov/vocabulary/languages/kar,
-language,kas,Kashmiri,http://id.loc.gov/vocabulary/languages/kas,
-language,kau,Kanuri,http://id.loc.gov/vocabulary/languages/kau,
+language,kas,Kashmiri,http://id.loc.gov/vocabulary/languages/kas,ks
+language,kau,Kanuri,http://id.loc.gov/vocabulary/languages/kau,kr
 language,kaw,Kawi,http://id.loc.gov/vocabulary/languages/kaw,
-language,kaz,Kazakh,http://id.loc.gov/vocabulary/languages/kaz,
+language,kaz,Kazakh,http://id.loc.gov/vocabulary/languages/kaz,kk
 language,kbd,Kabardian,http://id.loc.gov/vocabulary/languages/kbd,
 language,kha,Khasi,http://id.loc.gov/vocabulary/languages/kha,
 language,khi,Khoisan (Other),http://id.loc.gov/vocabulary/languages/khi,
-language,khm,Khmer,http://id.loc.gov/vocabulary/languages/khm,
+language,khm,Khmer,http://id.loc.gov/vocabulary/languages/khm,km
 language,kho,Khotanese,http://id.loc.gov/vocabulary/languages/kho,
-language,kik,Kikuyu,http://id.loc.gov/vocabulary/languages/kik,
-language,kin,Kinyarwanda,http://id.loc.gov/vocabulary/languages/kin,
-language,kir,Kyrgyz,http://id.loc.gov/vocabulary/languages/kir,
+language,kik,Kikuyu,http://id.loc.gov/vocabulary/languages/kik,ki
+language,kin,Kinyarwanda,http://id.loc.gov/vocabulary/languages/kin,rw
+language,kir,Kyrgyz,http://id.loc.gov/vocabulary/languages/kir,ky
 language,kmb,Kimbundu,http://id.loc.gov/vocabulary/languages/kmb,
 language,kok,Konkani,http://id.loc.gov/vocabulary/languages/kok,
-language,kom,Komi,http://id.loc.gov/vocabulary/languages/kom,
-language,kon,Kongo,http://id.loc.gov/vocabulary/languages/kon,
-language,kor,Korean,http://id.loc.gov/vocabulary/languages/kor,
+language,kom,Komi,http://id.loc.gov/vocabulary/languages/kom,kv
+language,kon,Kongo,http://id.loc.gov/vocabulary/languages/kon,kg
+language,kor,Korean,http://id.loc.gov/vocabulary/languages/kor,ko
 language,kos,Kosraean,http://id.loc.gov/vocabulary/languages/kos,
 language,kpe,Kpelle,http://id.loc.gov/vocabulary/languages/kpe,
 language,krc,Karachay-Balkar,http://id.loc.gov/vocabulary/languages/krc,
 language,krl,Karelian,http://id.loc.gov/vocabulary/languages/krl,
 language,kro,Kru (Other),http://id.loc.gov/vocabulary/languages/kro,
 language,kru,Kurukh,http://id.loc.gov/vocabulary/languages/kru,
-language,kua,Kuanyama,http://id.loc.gov/vocabulary/languages/kua,
+language,kua,Kuanyama,http://id.loc.gov/vocabulary/languages/kua,kj
 language,kum,Kumyk,http://id.loc.gov/vocabulary/languages/kum,
-language,kur,Kurdish,http://id.loc.gov/vocabulary/languages/kur,
+language,kur,Kurdish,http://id.loc.gov/vocabulary/languages/kur,ku
 language,kut,Kootenai,http://id.loc.gov/vocabulary/languages/kut,
 language,lad,Ladino,http://id.loc.gov/vocabulary/languages/lad,
 language,lah,Lahndā,http://id.loc.gov/vocabulary/languages/lah,
 language,lam,Lamba (Zambia and Congo),http://id.loc.gov/vocabulary/languages/lam,
-language,lao,Lao,http://id.loc.gov/vocabulary/languages/lao,
-language,lat,Latin,http://id.loc.gov/vocabulary/languages/lat,
-language,lav,Latvian,http://id.loc.gov/vocabulary/languages/lav,
+language,lao,Lao,http://id.loc.gov/vocabulary/languages/lao,lo
+language,lat,Latin,http://id.loc.gov/vocabulary/languages/lat,la
+language,lav,Latvian,http://id.loc.gov/vocabulary/languages/lav,lv
 language,lez,Lezgian,http://id.loc.gov/vocabulary/languages/lez,
-language,lim,Limburgish,http://id.loc.gov/vocabulary/languages/lim,
-language,lin,Lingala,http://id.loc.gov/vocabulary/languages/lin,
-language,lit,Lithuanian,http://id.loc.gov/vocabulary/languages/lit,
+language,lim,Limburgish,http://id.loc.gov/vocabulary/languages/lim,li
+language,lin,Lingala,http://id.loc.gov/vocabulary/languages/lin,ln
+language,lit,Lithuanian,http://id.loc.gov/vocabulary/languages/lit,lt
 language,lol,Mongo-Nkundu,http://id.loc.gov/vocabulary/languages/lol,
 language,loz,Lozi,http://id.loc.gov/vocabulary/languages/loz,
-language,ltz,Luxembourgish,http://id.loc.gov/vocabulary/languages/ltz,
+language,ltz,Luxembourgish,http://id.loc.gov/vocabulary/languages/ltz,lb
 language,lua,Luba-Lulua,http://id.loc.gov/vocabulary/languages/lua,
-language,lub,Luba-Katanga,http://id.loc.gov/vocabulary/languages/lub,
-language,lug,Ganda,http://id.loc.gov/vocabulary/languages/lug,
+language,lub,Luba-Katanga,http://id.loc.gov/vocabulary/languages/lub,lu
+language,lug,Ganda,http://id.loc.gov/vocabulary/languages/lug,lg
 language,lui,Luiseño,http://id.loc.gov/vocabulary/languages/lui,
 language,lun,Lunda,http://id.loc.gov/vocabulary/languages/lun,
 language,luo,Luo (Kenya and Tanzania),http://id.loc.gov/vocabulary/languages/luo,
@@ -264,14 +264,14 @@ language,lus,Lushai,http://id.loc.gov/vocabulary/languages/lus,
 language,mac,Macedonian,http://id.loc.gov/vocabulary/languages/mac,
 language,mad,Madurese,http://id.loc.gov/vocabulary/languages/mad,
 language,mag,Magahi,http://id.loc.gov/vocabulary/languages/mag,
-language,mah,Marshallese,http://id.loc.gov/vocabulary/languages/mah,
+language,mah,Marshallese,http://id.loc.gov/vocabulary/languages/mah,mh
 language,mai,Maithili,http://id.loc.gov/vocabulary/languages/mai,
 language,mak,Makasar,http://id.loc.gov/vocabulary/languages/mak,
-language,mal,Malayalam,http://id.loc.gov/vocabulary/languages/mal,
+language,mal,Malayalam,http://id.loc.gov/vocabulary/languages/mal,ml
 language,man,Mandingo,http://id.loc.gov/vocabulary/languages/man,
 language,mao,Maori,http://id.loc.gov/vocabulary/languages/mao,
 language,map,Austronesian (Other),http://id.loc.gov/vocabulary/languages/map,
-language,mar,Marathi,http://id.loc.gov/vocabulary/languages/mar,
+language,mar,Marathi,http://id.loc.gov/vocabulary/languages/mar,mr
 language,mas,Maasai,http://id.loc.gov/vocabulary/languages/mas,
 language,may,Malay,http://id.loc.gov/vocabulary/languages/may,
 language,mdf,Moksha,http://id.loc.gov/vocabulary/languages/mdf,
@@ -282,13 +282,13 @@ language,mic,Micmac,http://id.loc.gov/vocabulary/languages/mic,
 language,min,Minangkabau,http://id.loc.gov/vocabulary/languages/min,
 language,mis,Miscellaneous languages,http://id.loc.gov/vocabulary/languages/mis,
 language,mkh,Mon-Khmer (Other),http://id.loc.gov/vocabulary/languages/mkh,
-language,mlg,Malagasy,http://id.loc.gov/vocabulary/languages/mlg,
-language,mlt,Maltese,http://id.loc.gov/vocabulary/languages/mlt,
+language,mlg,Malagasy,http://id.loc.gov/vocabulary/languages/mlg,mg
+language,mlt,Maltese,http://id.loc.gov/vocabulary/languages/mlt,mt
 language,mnc,Manchu,http://id.loc.gov/vocabulary/languages/mnc,
 language,mni,Manipuri,http://id.loc.gov/vocabulary/languages/mni,
 language,mno,Manobo languages,http://id.loc.gov/vocabulary/languages/mno,
 language,moh,Mohawk,http://id.loc.gov/vocabulary/languages/moh,
-language,mon,Mongolian,http://id.loc.gov/vocabulary/languages/mon,
+language,mon,Mongolian,http://id.loc.gov/vocabulary/languages/mon,mn
 language,mos,Mooré,http://id.loc.gov/vocabulary/languages/mos,
 language,mul,Multiple languages,http://id.loc.gov/vocabulary/languages/mul,
 language,mun,Munda (Other),http://id.loc.gov/vocabulary/languages/mun,
@@ -300,75 +300,75 @@ language,myv,Erzya,http://id.loc.gov/vocabulary/languages/myv,
 language,nah,Nahuatl,http://id.loc.gov/vocabulary/languages/nah,
 language,nai,North American Indian (Other),http://id.loc.gov/vocabulary/languages/nai,
 language,nap,Neapolitan Italian,http://id.loc.gov/vocabulary/languages/nap,
-language,nau,Nauru,http://id.loc.gov/vocabulary/languages/nau,
-language,nav,Navajo,http://id.loc.gov/vocabulary/languages/nav,
-language,nbl,Ndebele (South Africa),http://id.loc.gov/vocabulary/languages/nbl,
-language,nde,Ndebele (Zimbabwe),http://id.loc.gov/vocabulary/languages/nde,
-language,ndo,Ndonga,http://id.loc.gov/vocabulary/languages/ndo,
+language,nau,Nauru,http://id.loc.gov/vocabulary/languages/nau,na
+language,nav,Navajo,http://id.loc.gov/vocabulary/languages/nav,nv
+language,nbl,Ndebele (South Africa),http://id.loc.gov/vocabulary/languages/nbl,nr
+language,nde,Ndebele (Zimbabwe),http://id.loc.gov/vocabulary/languages/nde,nd
+language,ndo,Ndonga,http://id.loc.gov/vocabulary/languages/ndo,ng
 language,nds,Low German,http://id.loc.gov/vocabulary/languages/nds,
-language,nep,Nepali,http://id.loc.gov/vocabulary/languages/nep,
+language,nep,Nepali,http://id.loc.gov/vocabulary/languages/nep,ne
 language,new,Newari,http://id.loc.gov/vocabulary/languages/new,
 language,nia,Nias,http://id.loc.gov/vocabulary/languages/nia,
 language,nic,Niger-Kordofanian (Other),http://id.loc.gov/vocabulary/languages/nic,
 language,niu,Niuean,http://id.loc.gov/vocabulary/languages/niu,
-language,nno,Norwegian (Nynorsk),http://id.loc.gov/vocabulary/languages/nno,
-language,nob,Norwegian (Bokmål),http://id.loc.gov/vocabulary/languages/nob,
+language,nno,Norwegian (Nynorsk),http://id.loc.gov/vocabulary/languages/nno,nn
+language,nob,Norwegian (Bokmål),http://id.loc.gov/vocabulary/languages/nob,nb
 language,nog,Nogai,http://id.loc.gov/vocabulary/languages/nog,
 language,non,Old Norse,http://id.loc.gov/vocabulary/languages/non,
-language,nor,Norwegian,http://id.loc.gov/vocabulary/languages/nor,
+language,nor,Norwegian,http://id.loc.gov/vocabulary/languages/nor,no
 language,nqo,N'Ko,http://id.loc.gov/vocabulary/languages/nqo,
 language,nso,Northern Sotho,http://id.loc.gov/vocabulary/languages/nso,
 language,nub,Nubian languages,http://id.loc.gov/vocabulary/languages/nub,
 language,nwc,"Newari, Old",http://id.loc.gov/vocabulary/languages/nwc,
-language,nya,Nyanja,http://id.loc.gov/vocabulary/languages/nya,
+language,nya,Nyanja,http://id.loc.gov/vocabulary/languages/nya,ny
 language,nym,Nyamwezi,http://id.loc.gov/vocabulary/languages/nym,
 language,nyn,Nyankole,http://id.loc.gov/vocabulary/languages/nyn,
 language,nyo,Nyoro,http://id.loc.gov/vocabulary/languages/nyo,
 language,nzi,Nzima,http://id.loc.gov/vocabulary/languages/nzi,
-language,oci,Occitan (post-1500),http://id.loc.gov/vocabulary/languages/oci,
-language,oji,Ojibwa,http://id.loc.gov/vocabulary/languages/oji,
-language,ori,Oriya,http://id.loc.gov/vocabulary/languages/ori,
-language,orm,Oromo,http://id.loc.gov/vocabulary/languages/orm,
+language,oci,Occitan (post-1500),http://id.loc.gov/vocabulary/languages/oci,oc
+language,oji,Ojibwa,http://id.loc.gov/vocabulary/languages/oji,oj
+language,ori,Oriya,http://id.loc.gov/vocabulary/languages/ori,or
+language,orm,Oromo,http://id.loc.gov/vocabulary/languages/orm,om
 language,osa,Osage,http://id.loc.gov/vocabulary/languages/osa,
-language,oss,Ossetic,http://id.loc.gov/vocabulary/languages/oss,
+language,oss,Ossetic,http://id.loc.gov/vocabulary/languages/oss,os
 language,ota,"Turkish, Ottoman",http://id.loc.gov/vocabulary/languages/ota,
 language,oto,Otomian languages,http://id.loc.gov/vocabulary/languages/oto,
 language,paa,Papuan (Other),http://id.loc.gov/vocabulary/languages/paa,
 language,pag,Pangasinan,http://id.loc.gov/vocabulary/languages/pag,
 language,pal,Pahlavi,http://id.loc.gov/vocabulary/languages/pal,
 language,pam,Pampanga,http://id.loc.gov/vocabulary/languages/pam,
-language,pan,Panjabi,http://id.loc.gov/vocabulary/languages/pan,
+language,pan,Panjabi,http://id.loc.gov/vocabulary/languages/pan,pa
 language,pap,Papiamento,http://id.loc.gov/vocabulary/languages/pap,
 language,pau,Palauan,http://id.loc.gov/vocabulary/languages/pau,
 language,peo,Old Persian (ca. 600-400 B.C.),http://id.loc.gov/vocabulary/languages/peo,
 language,per,Persian,http://id.loc.gov/vocabulary/languages/per,
 language,phi,Philippine (Other),http://id.loc.gov/vocabulary/languages/phi,
 language,phn,Phoenician,http://id.loc.gov/vocabulary/languages/phn,
-language,pli,Pali,http://id.loc.gov/vocabulary/languages/pli,
-language,pol,Polish,http://id.loc.gov/vocabulary/languages/pol,
+language,pli,Pali,http://id.loc.gov/vocabulary/languages/pli,pi
+language,pol,Polish,http://id.loc.gov/vocabulary/languages/pol,pl
 language,pon,Pohnpeian,http://id.loc.gov/vocabulary/languages/pon,
-language,por,Portuguese,http://id.loc.gov/vocabulary/languages/por,
+language,por,Portuguese,http://id.loc.gov/vocabulary/languages/por,pt
 language,pra,Prakrit languages,http://id.loc.gov/vocabulary/languages/pra,
 language,pro,Provençal (to 1500),http://id.loc.gov/vocabulary/languages/pro,
-language,pus,Pushto,http://id.loc.gov/vocabulary/languages/pus,
-language,que,Quechua,http://id.loc.gov/vocabulary/languages/que,
+language,pus,Pushto,http://id.loc.gov/vocabulary/languages/pus,ps
+language,que,Quechua,http://id.loc.gov/vocabulary/languages/que,qu
 language,raj,Rajasthani,http://id.loc.gov/vocabulary/languages/raj,
 language,rap,Rapanui,http://id.loc.gov/vocabulary/languages/rap,
 language,rar,Rarotongan,http://id.loc.gov/vocabulary/languages/rar,
 language,roa,Romance (Other),http://id.loc.gov/vocabulary/languages/roa,
-language,roh,Raeto-Romance,http://id.loc.gov/vocabulary/languages/roh,
+language,roh,Raeto-Romance,http://id.loc.gov/vocabulary/languages/roh,rm
 language,rom,Romani,http://id.loc.gov/vocabulary/languages/rom,
 language,rum,Romanian,http://id.loc.gov/vocabulary/languages/rum,
-language,run,Rundi,http://id.loc.gov/vocabulary/languages/run,
+language,run,Rundi,http://id.loc.gov/vocabulary/languages/run,rn
 language,rup,Aromanian,http://id.loc.gov/vocabulary/languages/rup,
-language,rus,Russian,http://id.loc.gov/vocabulary/languages/rus,
+language,rus,Russian,http://id.loc.gov/vocabulary/languages/rus,ru
 language,sad,Sandawe,http://id.loc.gov/vocabulary/languages/sad,
-language,sag,Sango (Ubangi Creole),http://id.loc.gov/vocabulary/languages/sag,
+language,sag,Sango (Ubangi Creole),http://id.loc.gov/vocabulary/languages/sag,sg
 language,sah,Yakut,http://id.loc.gov/vocabulary/languages/sah,
 language,sai,South American Indian (Other),http://id.loc.gov/vocabulary/languages/sai,
 language,sal,Salishan languages,http://id.loc.gov/vocabulary/languages/sal,
 language,sam,Samaritan Aramaic,http://id.loc.gov/vocabulary/languages/sam,
-language,san,Sanskrit,http://id.loc.gov/vocabulary/languages/san,
+language,san,Sanskrit,http://id.loc.gov/vocabulary/languages/san,sa
 language,sas,Sasak,http://id.loc.gov/vocabulary/languages/sas,
 language,sat,Santali,http://id.loc.gov/vocabulary/languages/sat,
 language,scn,Sicilian Italian,http://id.loc.gov/vocabulary/languages/scn,
@@ -379,86 +379,86 @@ language,sga,"Irish, Old (to 1100)",http://id.loc.gov/vocabulary/languages/sga,
 language,sgn,Sign languages,http://id.loc.gov/vocabulary/languages/sgn,
 language,shn,Shan,http://id.loc.gov/vocabulary/languages/shn,
 language,sid,Sidamo,http://id.loc.gov/vocabulary/languages/sid,
-language,sin,Sinhalese,http://id.loc.gov/vocabulary/languages/sin,
+language,sin,Sinhalese,http://id.loc.gov/vocabulary/languages/sin,si
 language,sio,Siouan (Other),http://id.loc.gov/vocabulary/languages/sio,
 language,sit,Sino-Tibetan (Other),http://id.loc.gov/vocabulary/languages/sit,
 language,sla,Slavic (Other),http://id.loc.gov/vocabulary/languages/sla,
 language,slo,Slovak,http://id.loc.gov/vocabulary/languages/slo,
-language,slv,Slovenian,http://id.loc.gov/vocabulary/languages/slv,
+language,slv,Slovenian,http://id.loc.gov/vocabulary/languages/slv,sl
 language,sma,Southern Sami,http://id.loc.gov/vocabulary/languages/sma,
-language,sme,Northern Sami,http://id.loc.gov/vocabulary/languages/sme,
+language,sme,Northern Sami,http://id.loc.gov/vocabulary/languages/sme,se
 language,smi,Sami,http://id.loc.gov/vocabulary/languages/smi,
 language,smj,Lule Sami,http://id.loc.gov/vocabulary/languages/smj,
 language,smn,Inari Sami,http://id.loc.gov/vocabulary/languages/smn,
-language,smo,Samoan,http://id.loc.gov/vocabulary/languages/smo,
+language,smo,Samoan,http://id.loc.gov/vocabulary/languages/smo,sm
 language,sms,Skolt Sami,http://id.loc.gov/vocabulary/languages/sms,
-language,sna,Shona,http://id.loc.gov/vocabulary/languages/sna,
-language,snd,Sindhi,http://id.loc.gov/vocabulary/languages/snd,
+language,sna,Shona,http://id.loc.gov/vocabulary/languages/sna,sn
+language,snd,Sindhi,http://id.loc.gov/vocabulary/languages/snd,sd
 language,snk,Soninke,http://id.loc.gov/vocabulary/languages/snk,
 language,sog,Sogdian,http://id.loc.gov/vocabulary/languages/sog,
-language,som,Somali,http://id.loc.gov/vocabulary/languages/som,
+language,som,Somali,http://id.loc.gov/vocabulary/languages/som,so
 language,son,Songhai,http://id.loc.gov/vocabulary/languages/son,
-language,sot,Sotho,http://id.loc.gov/vocabulary/languages/sot,
-language,spa,Spanish,http://id.loc.gov/vocabulary/languages/spa,
-language,srd,Sardinian,http://id.loc.gov/vocabulary/languages/srd,
+language,sot,Sotho,http://id.loc.gov/vocabulary/languages/sot,st
+language,spa,Spanish,http://id.loc.gov/vocabulary/languages/spa,es
+language,srd,Sardinian,http://id.loc.gov/vocabulary/languages/srd,sc
 language,srn,Sranan,http://id.loc.gov/vocabulary/languages/srn,
-language,srp,Serbian,http://id.loc.gov/vocabulary/languages/srp,
+language,srp,Serbian,http://id.loc.gov/vocabulary/languages/srp,sr
 language,srr,Serer,http://id.loc.gov/vocabulary/languages/srr,
 language,ssa,Nilo-Saharan (Other),http://id.loc.gov/vocabulary/languages/ssa,
-language,ssw,Swazi,http://id.loc.gov/vocabulary/languages/ssw,
+language,ssw,Swazi,http://id.loc.gov/vocabulary/languages/ssw,ss
 language,suk,Sukuma,http://id.loc.gov/vocabulary/languages/suk,
-language,sun,Sundanese,http://id.loc.gov/vocabulary/languages/sun,
+language,sun,Sundanese,http://id.loc.gov/vocabulary/languages/sun,su
 language,sus,Susu,http://id.loc.gov/vocabulary/languages/sus,
 language,sux,Sumerian,http://id.loc.gov/vocabulary/languages/sux,
-language,swa,Swahili,http://id.loc.gov/vocabulary/languages/swa,
-language,swe,Swedish,http://id.loc.gov/vocabulary/languages/swe,
+language,swa,Swahili,http://id.loc.gov/vocabulary/languages/swa,sw
+language,swe,Swedish,http://id.loc.gov/vocabulary/languages/swe,sv
 language,syc,Syriac,http://id.loc.gov/vocabulary/languages/syc,
 language,syr,"Syriac, Modern",http://id.loc.gov/vocabulary/languages/syr,
-language,tah,Tahitian,http://id.loc.gov/vocabulary/languages/tah,
+language,tah,Tahitian,http://id.loc.gov/vocabulary/languages/tah,ty
 language,tai,Tai (Other),http://id.loc.gov/vocabulary/languages/tai,
-language,tam,Tamil,http://id.loc.gov/vocabulary/languages/tam,
-language,tat,Tatar,http://id.loc.gov/vocabulary/languages/tat,
-language,tel,Telugu,http://id.loc.gov/vocabulary/languages/tel,
+language,tam,Tamil,http://id.loc.gov/vocabulary/languages/tam,ta
+language,tat,Tatar,http://id.loc.gov/vocabulary/languages/tat,tt
+language,tel,Telugu,http://id.loc.gov/vocabulary/languages/tel,te
 language,tem,Temne,http://id.loc.gov/vocabulary/languages/tem,
 language,ter,Terena,http://id.loc.gov/vocabulary/languages/ter,
 language,tet,Tetum,http://id.loc.gov/vocabulary/languages/tet,
-language,tgk,Tajik,http://id.loc.gov/vocabulary/languages/tgk,
-language,tgl,Tagalog,http://id.loc.gov/vocabulary/languages/tgl,
-language,tha,Thai,http://id.loc.gov/vocabulary/languages/tha,
+language,tgk,Tajik,http://id.loc.gov/vocabulary/languages/tgk,tg
+language,tgl,Tagalog,http://id.loc.gov/vocabulary/languages/tgl,tl
+language,tha,Thai,http://id.loc.gov/vocabulary/languages/tha,th
 language,tib,Tibetan,http://id.loc.gov/vocabulary/languages/tib,
 language,tig,Tigré,http://id.loc.gov/vocabulary/languages/tig,
-language,tir,Tigrinya,http://id.loc.gov/vocabulary/languages/tir,
+language,tir,Tigrinya,http://id.loc.gov/vocabulary/languages/tir,ti
 language,tiv,Tiv,http://id.loc.gov/vocabulary/languages/tiv,
 language,tkl,Tokelauan,http://id.loc.gov/vocabulary/languages/tkl,
 language,tlh,Klingon (Artificial language),http://id.loc.gov/vocabulary/languages/tlh,
 language,tli,Tlingit,http://id.loc.gov/vocabulary/languages/tli,
 language,tmh,Tamashek,http://id.loc.gov/vocabulary/languages/tmh,
 language,tog,Tonga (Nyasa),http://id.loc.gov/vocabulary/languages/tog,
-language,ton,Tongan,http://id.loc.gov/vocabulary/languages/ton,
+language,ton,Tongan,http://id.loc.gov/vocabulary/languages/ton,to
 language,tpi,Tok Pisin,http://id.loc.gov/vocabulary/languages/tpi,
 language,tsi,Tsimshian,http://id.loc.gov/vocabulary/languages/tsi,
-language,tsn,Tswana,http://id.loc.gov/vocabulary/languages/tsn,
-language,tso,Tsonga,http://id.loc.gov/vocabulary/languages/tso,
-language,tuk,Turkmen,http://id.loc.gov/vocabulary/languages/tuk,
+language,tsn,Tswana,http://id.loc.gov/vocabulary/languages/tsn,tn
+language,tso,Tsonga,http://id.loc.gov/vocabulary/languages/tso,ts
+language,tuk,Turkmen,http://id.loc.gov/vocabulary/languages/tuk,tk
 language,tum,Tumbuka,http://id.loc.gov/vocabulary/languages/tum,
 language,tup,Tupi languages,http://id.loc.gov/vocabulary/languages/tup,
-language,tur,Turkish,http://id.loc.gov/vocabulary/languages/tur,
+language,tur,Turkish,http://id.loc.gov/vocabulary/languages/tur,tr
 language,tut,Altaic (Other),http://id.loc.gov/vocabulary/languages/tut,
 language,tvl,Tuvaluan,http://id.loc.gov/vocabulary/languages/tvl,
-language,twi,Twi,http://id.loc.gov/vocabulary/languages/twi,
+language,twi,Twi,http://id.loc.gov/vocabulary/languages/twi,tw
 language,tyv,Tuvinian,http://id.loc.gov/vocabulary/languages/tyv,
 language,udm,Udmurt,http://id.loc.gov/vocabulary/languages/udm,
 language,uga,Ugaritic,http://id.loc.gov/vocabulary/languages/uga,
-language,uig,Uighur,http://id.loc.gov/vocabulary/languages/uig,
-language,ukr,Ukrainian,http://id.loc.gov/vocabulary/languages/ukr,
+language,uig,Uighur,http://id.loc.gov/vocabulary/languages/uig,ug
+language,ukr,Ukrainian,http://id.loc.gov/vocabulary/languages/ukr,uk
 language,umb,Umbundu,http://id.loc.gov/vocabulary/languages/umb,
 language,und,Undetermined,http://id.loc.gov/vocabulary/languages/und,
-language,urd,Urdu,http://id.loc.gov/vocabulary/languages/urd,
-language,uzb,Uzbek,http://id.loc.gov/vocabulary/languages/uzb,
+language,urd,Urdu,http://id.loc.gov/vocabulary/languages/urd,ur
+language,uzb,Uzbek,http://id.loc.gov/vocabulary/languages/uzb,uz
 language,vai,Vai,http://id.loc.gov/vocabulary/languages/vai,
-language,ven,Venda,http://id.loc.gov/vocabulary/languages/ven,
-language,vie,Vietnamese,http://id.loc.gov/vocabulary/languages/vie,
-language,vol,Volapük,http://id.loc.gov/vocabulary/languages/vol,
+language,ven,Venda,http://id.loc.gov/vocabulary/languages/ven,ve
+language,vie,Vietnamese,http://id.loc.gov/vocabulary/languages/vie,vi
+language,vol,Volapük,http://id.loc.gov/vocabulary/languages/vol,vo
 language,vot,Votic,http://id.loc.gov/vocabulary/languages/vot,
 language,wak,Wakashan languages,http://id.loc.gov/vocabulary/languages/wak,
 language,wal,Wolayta,http://id.loc.gov/vocabulary/languages/wal,
@@ -466,21 +466,21 @@ language,war,Waray,http://id.loc.gov/vocabulary/languages/war,
 language,was,Washoe,http://id.loc.gov/vocabulary/languages/was,
 language,wel,Welsh,http://id.loc.gov/vocabulary/languages/wel,
 language,wen,Sorbian (Other),http://id.loc.gov/vocabulary/languages/wen,
-language,wln,Walloon,http://id.loc.gov/vocabulary/languages/wln,
-language,wol,Wolof,http://id.loc.gov/vocabulary/languages/wol,
+language,wln,Walloon,http://id.loc.gov/vocabulary/languages/wln,wa
+language,wol,Wolof,http://id.loc.gov/vocabulary/languages/wol,wo
 language,xal,Oirat,http://id.loc.gov/vocabulary/languages/xal,
-language,xho,Xhosa,http://id.loc.gov/vocabulary/languages/xho,
+language,xho,Xhosa,http://id.loc.gov/vocabulary/languages/xho,xh
 language,yao,Yao (Africa),http://id.loc.gov/vocabulary/languages/yao,
 language,yap,Yapese,http://id.loc.gov/vocabulary/languages/yap,
-language,yid,Yiddish,http://id.loc.gov/vocabulary/languages/yid,
-language,yor,Yoruba,http://id.loc.gov/vocabulary/languages/yor,
+language,yid,Yiddish,http://id.loc.gov/vocabulary/languages/yid,yi
+language,yor,Yoruba,http://id.loc.gov/vocabulary/languages/yor,yo
 language,ypk,Yupik languages,http://id.loc.gov/vocabulary/languages/ypk,
 language,zap,Zapotec,http://id.loc.gov/vocabulary/languages/zap,
 language,zbl,Blissymbolics,http://id.loc.gov/vocabulary/languages/zbl,
 language,zen,Zenaga,http://id.loc.gov/vocabulary/languages/zen,
-language,zha,Zhuang,http://id.loc.gov/vocabulary/languages/zha,
+language,zha,Zhuang,http://id.loc.gov/vocabulary/languages/zha,za
 language,znd,Zande languages,http://id.loc.gov/vocabulary/languages/znd,
-language,zul,Zulu,http://id.loc.gov/vocabulary/languages/zul,
+language,zul,Zulu,http://id.loc.gov/vocabulary/languages/zul,zu
 language,zun,Zuni,http://id.loc.gov/vocabulary/languages/zun,
 language,zxx,No linguistic content,http://id.loc.gov/vocabulary/languages/zxx,
 language,zza,Zaza,http://id.loc.gov/vocabulary/languages/zza,

--- a/web/modules/custom/asu_taxonomies/migrate/languages.csv
+++ b/web/modules/custom/asu_taxonomies/migrate/languages.csv
@@ -1,486 +1,486 @@
-﻿vid,code,name,uri
-language,aar,Afar,http://id.loc.gov/vocabulary/languages/aar
-language,abk,Abkhaz,http://id.loc.gov/vocabulary/languages/abk
-language,ace,Achinese,http://id.loc.gov/vocabulary/languages/ace
-language,ach,Acoli,http://id.loc.gov/vocabulary/languages/ach
-language,ada,Adangme,http://id.loc.gov/vocabulary/languages/ada
-language,ady,Adygei,http://id.loc.gov/vocabulary/languages/ady
-language,afa,Afroasiatic (Other),http://id.loc.gov/vocabulary/languages/afa
-language,afh,Afrihili (Artificial language),http://id.loc.gov/vocabulary/languages/afh
-language,afr,Afrikaans,http://id.loc.gov/vocabulary/languages/afr
-language,ain,Ainu,http://id.loc.gov/vocabulary/languages/ain
-language,aka,Akan,http://id.loc.gov/vocabulary/languages/aka
-language,akk,Akkadian,http://id.loc.gov/vocabulary/languages/akk
-language,alb,Albanian,http://id.loc.gov/vocabulary/languages/alb
-language,ale,Aleut,http://id.loc.gov/vocabulary/languages/ale
-language,alg,Algonquian (Other),http://id.loc.gov/vocabulary/languages/alg
-language,alt,Altai,http://id.loc.gov/vocabulary/languages/alt
-language,amh,Amharic,http://id.loc.gov/vocabulary/languages/amh
-language,ang,"English, Old (ca. 450-1100)",http://id.loc.gov/vocabulary/languages/ang
-language,anp,Angika,http://id.loc.gov/vocabulary/languages/anp
-language,apa,Apache languages,http://id.loc.gov/vocabulary/languages/apa
-language,ara,Arabic,http://id.loc.gov/vocabulary/languages/ara
-language,arc,Aramaic,http://id.loc.gov/vocabulary/languages/arc
-language,arg,Aragonese,http://id.loc.gov/vocabulary/languages/arg
-language,arm,Armenian,http://id.loc.gov/vocabulary/languages/arm
-language,arn,Mapuche,http://id.loc.gov/vocabulary/languages/arn
-language,arp,Arapaho,http://id.loc.gov/vocabulary/languages/arp
-language,art,Artificial (Other),http://id.loc.gov/vocabulary/languages/art
-language,arw,Arawak,http://id.loc.gov/vocabulary/languages/arw
-language,asm,Assamese,http://id.loc.gov/vocabulary/languages/asm
-language,ast,Bable,http://id.loc.gov/vocabulary/languages/ast
-language,ath,Athapascan (Other),http://id.loc.gov/vocabulary/languages/ath
-language,aus,Australian languages,http://id.loc.gov/vocabulary/languages/aus
-language,ava,Avaric,http://id.loc.gov/vocabulary/languages/ava
-language,ave,Avestan,http://id.loc.gov/vocabulary/languages/ave
-language,awa,Awadhi,http://id.loc.gov/vocabulary/languages/awa
-language,aym,Aymara,http://id.loc.gov/vocabulary/languages/aym
-language,aze,Azerbaijani,http://id.loc.gov/vocabulary/languages/aze
-language,bad,Banda languages,http://id.loc.gov/vocabulary/languages/bad
-language,bai,Bamileke languages,http://id.loc.gov/vocabulary/languages/bai
-language,bak,Bashkir,http://id.loc.gov/vocabulary/languages/bak
-language,bal,Baluchi,http://id.loc.gov/vocabulary/languages/bal
-language,bam,Bambara,http://id.loc.gov/vocabulary/languages/bam
-language,ban,Balinese,http://id.loc.gov/vocabulary/languages/ban
-language,baq,Basque,http://id.loc.gov/vocabulary/languages/baq
-language,bas,Basa,http://id.loc.gov/vocabulary/languages/bas
-language,bat,Baltic (Other),http://id.loc.gov/vocabulary/languages/bat
-language,bej,Beja,http://id.loc.gov/vocabulary/languages/bej
-language,bel,Belarusian,http://id.loc.gov/vocabulary/languages/bel
-language,bem,Bemba,http://id.loc.gov/vocabulary/languages/bem
-language,ben,Bengali,http://id.loc.gov/vocabulary/languages/ben
-language,ber,Berber (Other),http://id.loc.gov/vocabulary/languages/ber
-language,bho,Bhojpuri,http://id.loc.gov/vocabulary/languages/bho
-language,bih,Bihari (Other),http://id.loc.gov/vocabulary/languages/bih
-language,bik,Bikol,http://id.loc.gov/vocabulary/languages/bik
-language,bin,Edo,http://id.loc.gov/vocabulary/languages/bin
-language,bis,Bislama,http://id.loc.gov/vocabulary/languages/bis
-language,bla,Siksika,http://id.loc.gov/vocabulary/languages/bla
-language,bnt,Bantu (Other),http://id.loc.gov/vocabulary/languages/bnt
-language,bos,Bosnian,http://id.loc.gov/vocabulary/languages/bos
-language,bra,Braj,http://id.loc.gov/vocabulary/languages/bra
-language,bre,Breton,http://id.loc.gov/vocabulary/languages/bre
-language,btk,Batak,http://id.loc.gov/vocabulary/languages/btk
-language,bua,Buriat,http://id.loc.gov/vocabulary/languages/bua
-language,bug,Bugis,http://id.loc.gov/vocabulary/languages/bug
-language,bul,Bulgarian,http://id.loc.gov/vocabulary/languages/bul
-language,bur,Burmese,http://id.loc.gov/vocabulary/languages/bur
-language,byn,Bilin,http://id.loc.gov/vocabulary/languages/byn
-language,cad,Caddo,http://id.loc.gov/vocabulary/languages/cad
-language,cai,Central American Indian (Other),http://id.loc.gov/vocabulary/languages/cai
-language,car,Carib,http://id.loc.gov/vocabulary/languages/car
-language,cat,Catalan,http://id.loc.gov/vocabulary/languages/cat
-language,cau,Caucasian (Other),http://id.loc.gov/vocabulary/languages/cau
-language,ceb,Cebuano,http://id.loc.gov/vocabulary/languages/ceb
-language,cel,Celtic (Other),http://id.loc.gov/vocabulary/languages/cel
-language,cha,Chamorro,http://id.loc.gov/vocabulary/languages/cha
-language,chb,Chibcha,http://id.loc.gov/vocabulary/languages/chb
-language,che,Chechen,http://id.loc.gov/vocabulary/languages/che
-language,chg,Chagatai,http://id.loc.gov/vocabulary/languages/chg
-language,chi,Chinese,http://id.loc.gov/vocabulary/languages/chi
-language,chk,Chuukese,http://id.loc.gov/vocabulary/languages/chk
-language,chm,Mari,http://id.loc.gov/vocabulary/languages/chm
-language,chn,Chinook jargon,http://id.loc.gov/vocabulary/languages/chn
-language,cho,Choctaw,http://id.loc.gov/vocabulary/languages/cho
-language,chp,Chipewyan,http://id.loc.gov/vocabulary/languages/chp
-language,chr,Cherokee,http://id.loc.gov/vocabulary/languages/chr
-language,chu,Church Slavic,http://id.loc.gov/vocabulary/languages/chu
-language,chv,Chuvash,http://id.loc.gov/vocabulary/languages/chv
-language,chy,Cheyenne,http://id.loc.gov/vocabulary/languages/chy
-language,cmc,Chamic languages,http://id.loc.gov/vocabulary/languages/cmc
-language,cnr,Montenegrin,http://id.loc.gov/vocabulary/languages/cnr
-language,cop,Coptic,http://id.loc.gov/vocabulary/languages/cop
-language,cor,Cornish,http://id.loc.gov/vocabulary/languages/cor
-language,cos,Corsican,http://id.loc.gov/vocabulary/languages/cos
-language,cpe,"Creoles and Pidgins, English-based (Other)",http://id.loc.gov/vocabulary/languages/cpe
-language,cpf,"Creoles and Pidgins, French-based (Other)",http://id.loc.gov/vocabulary/languages/cpf
-language,cpp,"Creoles and Pidgins, Portuguese-based (Other)",http://id.loc.gov/vocabulary/languages/cpp
-language,cre,Cree,http://id.loc.gov/vocabulary/languages/cre
-language,crh,Crimean Tatar,http://id.loc.gov/vocabulary/languages/crh
-language,crp,Creoles and Pidgins (Other),http://id.loc.gov/vocabulary/languages/crp
-language,csb,Kashubian,http://id.loc.gov/vocabulary/languages/csb
-language,cus,Cushitic (Other),http://id.loc.gov/vocabulary/languages/cus
-language,cze,Czech,http://id.loc.gov/vocabulary/languages/cze
-language,dak,Dakota,http://id.loc.gov/vocabulary/languages/dak
-language,dan,Danish,http://id.loc.gov/vocabulary/languages/dan
-language,dar,Dargwa,http://id.loc.gov/vocabulary/languages/dar
-language,day,Dayak,http://id.loc.gov/vocabulary/languages/day
-language,del,Delaware,http://id.loc.gov/vocabulary/languages/del
-language,den,Slavey,http://id.loc.gov/vocabulary/languages/den
-language,dgr,Dogrib,http://id.loc.gov/vocabulary/languages/dgr
-language,din,Dinka,http://id.loc.gov/vocabulary/languages/din
-language,div,Divehi,http://id.loc.gov/vocabulary/languages/div
-language,doi,Dogri,http://id.loc.gov/vocabulary/languages/doi
-language,dra,Dravidian (Other),http://id.loc.gov/vocabulary/languages/dra
-language,dsb,Lower Sorbian,http://id.loc.gov/vocabulary/languages/dsb
-language,dua,Duala,http://id.loc.gov/vocabulary/languages/dua
-language,dum,"Dutch, Middle (ca. 1050-1350)",http://id.loc.gov/vocabulary/languages/dum
-language,dut,Dutch,http://id.loc.gov/vocabulary/languages/dut
-language,dyu,Dyula,http://id.loc.gov/vocabulary/languages/dyu
-language,dzo,Dzongkha,http://id.loc.gov/vocabulary/languages/dzo
-language,efi,Efik,http://id.loc.gov/vocabulary/languages/efi
-language,egy,Egyptian,http://id.loc.gov/vocabulary/languages/egy
-language,eka,Ekajuk,http://id.loc.gov/vocabulary/languages/eka
-language,elx,Elamite,http://id.loc.gov/vocabulary/languages/elx
-language,eng,English,http://id.loc.gov/vocabulary/languages/eng
-language,enm,"English, Middle (1100-1500)",http://id.loc.gov/vocabulary/languages/enm
-language,epo,Esperanto,http://id.loc.gov/vocabulary/languages/epo
-language,est,Estonian,http://id.loc.gov/vocabulary/languages/est
-language,ewe,Ewe,http://id.loc.gov/vocabulary/languages/ewe
-language,ewo,Ewondo,http://id.loc.gov/vocabulary/languages/ewo
-language,fan,Fang,http://id.loc.gov/vocabulary/languages/fan
-language,fao,Faroese,http://id.loc.gov/vocabulary/languages/fao
-language,fat,Fanti,http://id.loc.gov/vocabulary/languages/fat
-language,fij,Fijian,http://id.loc.gov/vocabulary/languages/fij
-language,fil,Filipino,http://id.loc.gov/vocabulary/languages/fil
-language,fin,Finnish,http://id.loc.gov/vocabulary/languages/fin
-language,fiu,Finno-Ugrian (Other),http://id.loc.gov/vocabulary/languages/fiu
-language,fon,Fon,http://id.loc.gov/vocabulary/languages/fon
-language,fre,French,http://id.loc.gov/vocabulary/languages/fre
-language,frm,"French, Middle (ca. 1300-1600)",http://id.loc.gov/vocabulary/languages/frm
-language,fro,"French, Old (ca. 842-1300)",http://id.loc.gov/vocabulary/languages/fro
-language,frr,North Frisian,http://id.loc.gov/vocabulary/languages/frr
-language,frs,East Frisian,http://id.loc.gov/vocabulary/languages/frs
-language,fry,Frisian,http://id.loc.gov/vocabulary/languages/fry
-language,ful,Fula,http://id.loc.gov/vocabulary/languages/ful
-language,fur,Friulian,http://id.loc.gov/vocabulary/languages/fur
-language,gaa,Gã,http://id.loc.gov/vocabulary/languages/gaa
-language,gay,Gayo,http://id.loc.gov/vocabulary/languages/gay
-language,gba,Gbaya,http://id.loc.gov/vocabulary/languages/gba
-language,gem,Germanic (Other),http://id.loc.gov/vocabulary/languages/gem
-language,geo,Georgian,http://id.loc.gov/vocabulary/languages/geo
-language,ger,German,http://id.loc.gov/vocabulary/languages/ger
-language,gez,Ethiopic,http://id.loc.gov/vocabulary/languages/gez
-language,gil,Gilbertese,http://id.loc.gov/vocabulary/languages/gil
-language,gla,Scottish Gaelic,http://id.loc.gov/vocabulary/languages/gla
-language,gle,Irish,http://id.loc.gov/vocabulary/languages/gle
-language,glg,Galician,http://id.loc.gov/vocabulary/languages/glg
-language,glv,Manx,http://id.loc.gov/vocabulary/languages/glv
-language,gmh,"German, Middle High (ca. 1050-1500)",http://id.loc.gov/vocabulary/languages/gmh
-language,goh,"German, Old High (ca. 750-1050)",http://id.loc.gov/vocabulary/languages/goh
-language,gon,Gondi,http://id.loc.gov/vocabulary/languages/gon
-language,gor,Gorontalo,http://id.loc.gov/vocabulary/languages/gor
-language,got,Gothic,http://id.loc.gov/vocabulary/languages/got
-language,grb,Grebo,http://id.loc.gov/vocabulary/languages/grb
-language,grc,"Greek, Ancient (to 1453)",http://id.loc.gov/vocabulary/languages/grc
-language,gre,"Greek, Modern (1453-)",http://id.loc.gov/vocabulary/languages/gre
-language,grn,Guarani,http://id.loc.gov/vocabulary/languages/grn
-language,gsw,Swiss German,http://id.loc.gov/vocabulary/languages/gsw
-language,guj,Gujarati,http://id.loc.gov/vocabulary/languages/guj
-language,gwi,Gwich'in,http://id.loc.gov/vocabulary/languages/gwi
-language,hai,Haida,http://id.loc.gov/vocabulary/languages/hai
-language,hat,Haitian French Creole,http://id.loc.gov/vocabulary/languages/hat
-language,hau,Hausa,http://id.loc.gov/vocabulary/languages/hau
-language,haw,Hawaiian,http://id.loc.gov/vocabulary/languages/haw
-language,heb,Hebrew,http://id.loc.gov/vocabulary/languages/heb
-language,her,Herero,http://id.loc.gov/vocabulary/languages/her
-language,hil,Hiligaynon,http://id.loc.gov/vocabulary/languages/hil
-language,him,Western Pahari languages,http://id.loc.gov/vocabulary/languages/him
-language,hin,Hindi,http://id.loc.gov/vocabulary/languages/hin
-language,hit,Hittite,http://id.loc.gov/vocabulary/languages/hit
-language,hmn,Hmong,http://id.loc.gov/vocabulary/languages/hmn
-language,hmo,Hiri Motu,http://id.loc.gov/vocabulary/languages/hmo
-language,hrv,Croatian,http://id.loc.gov/vocabulary/languages/hrv
-language,hsb,Upper Sorbian,http://id.loc.gov/vocabulary/languages/hsb
-language,hun,Hungarian,http://id.loc.gov/vocabulary/languages/hun
-language,hup,Hupa,http://id.loc.gov/vocabulary/languages/hup
-language,iba,Iban,http://id.loc.gov/vocabulary/languages/iba
-language,ibo,Igbo,http://id.loc.gov/vocabulary/languages/ibo
-language,ice,Icelandic,http://id.loc.gov/vocabulary/languages/ice
-language,ido,Ido,http://id.loc.gov/vocabulary/languages/ido
-language,iii,Sichuan Yi,http://id.loc.gov/vocabulary/languages/iii
-language,ijo,Ijo,http://id.loc.gov/vocabulary/languages/ijo
-language,iku,Inuktitut,http://id.loc.gov/vocabulary/languages/iku
-language,ile,Interlingue,http://id.loc.gov/vocabulary/languages/ile
-language,ilo,Iloko,http://id.loc.gov/vocabulary/languages/ilo
-language,ina,Interlingua (International Auxiliary Language Association),http://id.loc.gov/vocabulary/languages/ina
-language,inc,Indic (Other),http://id.loc.gov/vocabulary/languages/inc
-language,ind,Indonesian,http://id.loc.gov/vocabulary/languages/ind
-language,ine,Indo-European (Other),http://id.loc.gov/vocabulary/languages/ine
-language,inh,Ingush,http://id.loc.gov/vocabulary/languages/inh
-language,ipk,Inupiaq,http://id.loc.gov/vocabulary/languages/ipk
-language,ira,Iranian (Other),http://id.loc.gov/vocabulary/languages/ira
-language,iro,Iroquoian (Other),http://id.loc.gov/vocabulary/languages/iro
-language,ita,Italian,http://id.loc.gov/vocabulary/languages/ita
-language,jav,Javanese,http://id.loc.gov/vocabulary/languages/jav
-language,jbo,Lojban (Artificial language),http://id.loc.gov/vocabulary/languages/jbo
-language,jpn,Japanese,http://id.loc.gov/vocabulary/languages/jpn
-language,jpr,Judeo-Persian,http://id.loc.gov/vocabulary/languages/jpr
-language,jrb,Judeo-Arabic,http://id.loc.gov/vocabulary/languages/jrb
-language,kaa,Kara-Kalpak,http://id.loc.gov/vocabulary/languages/kaa
-language,kab,Kabyle,http://id.loc.gov/vocabulary/languages/kab
-language,kac,Kachin,http://id.loc.gov/vocabulary/languages/kac
-language,kal,Kalâtdlisut,http://id.loc.gov/vocabulary/languages/kal
-language,kam,Kamba,http://id.loc.gov/vocabulary/languages/kam
-language,kan,Kannada,http://id.loc.gov/vocabulary/languages/kan
-language,kar,Karen languages,http://id.loc.gov/vocabulary/languages/kar
-language,kas,Kashmiri,http://id.loc.gov/vocabulary/languages/kas
-language,kau,Kanuri,http://id.loc.gov/vocabulary/languages/kau
-language,kaw,Kawi,http://id.loc.gov/vocabulary/languages/kaw
-language,kaz,Kazakh,http://id.loc.gov/vocabulary/languages/kaz
-language,kbd,Kabardian,http://id.loc.gov/vocabulary/languages/kbd
-language,kha,Khasi,http://id.loc.gov/vocabulary/languages/kha
-language,khi,Khoisan (Other),http://id.loc.gov/vocabulary/languages/khi
-language,khm,Khmer,http://id.loc.gov/vocabulary/languages/khm
-language,kho,Khotanese,http://id.loc.gov/vocabulary/languages/kho
-language,kik,Kikuyu,http://id.loc.gov/vocabulary/languages/kik
-language,kin,Kinyarwanda,http://id.loc.gov/vocabulary/languages/kin
-language,kir,Kyrgyz,http://id.loc.gov/vocabulary/languages/kir
-language,kmb,Kimbundu,http://id.loc.gov/vocabulary/languages/kmb
-language,kok,Konkani,http://id.loc.gov/vocabulary/languages/kok
-language,kom,Komi,http://id.loc.gov/vocabulary/languages/kom
-language,kon,Kongo,http://id.loc.gov/vocabulary/languages/kon
-language,kor,Korean,http://id.loc.gov/vocabulary/languages/kor
-language,kos,Kosraean,http://id.loc.gov/vocabulary/languages/kos
-language,kpe,Kpelle,http://id.loc.gov/vocabulary/languages/kpe
-language,krc,Karachay-Balkar,http://id.loc.gov/vocabulary/languages/krc
-language,krl,Karelian,http://id.loc.gov/vocabulary/languages/krl
-language,kro,Kru (Other),http://id.loc.gov/vocabulary/languages/kro
-language,kru,Kurukh,http://id.loc.gov/vocabulary/languages/kru
-language,kua,Kuanyama,http://id.loc.gov/vocabulary/languages/kua
-language,kum,Kumyk,http://id.loc.gov/vocabulary/languages/kum
-language,kur,Kurdish,http://id.loc.gov/vocabulary/languages/kur
-language,kut,Kootenai,http://id.loc.gov/vocabulary/languages/kut
-language,lad,Ladino,http://id.loc.gov/vocabulary/languages/lad
-language,lah,Lahndā,http://id.loc.gov/vocabulary/languages/lah
-language,lam,Lamba (Zambia and Congo),http://id.loc.gov/vocabulary/languages/lam
-language,lao,Lao,http://id.loc.gov/vocabulary/languages/lao
-language,lat,Latin,http://id.loc.gov/vocabulary/languages/lat
-language,lav,Latvian,http://id.loc.gov/vocabulary/languages/lav
-language,lez,Lezgian,http://id.loc.gov/vocabulary/languages/lez
-language,lim,Limburgish,http://id.loc.gov/vocabulary/languages/lim
-language,lin,Lingala,http://id.loc.gov/vocabulary/languages/lin
-language,lit,Lithuanian,http://id.loc.gov/vocabulary/languages/lit
-language,lol,Mongo-Nkundu,http://id.loc.gov/vocabulary/languages/lol
-language,loz,Lozi,http://id.loc.gov/vocabulary/languages/loz
-language,ltz,Luxembourgish,http://id.loc.gov/vocabulary/languages/ltz
-language,lua,Luba-Lulua,http://id.loc.gov/vocabulary/languages/lua
-language,lub,Luba-Katanga,http://id.loc.gov/vocabulary/languages/lub
-language,lug,Ganda,http://id.loc.gov/vocabulary/languages/lug
-language,lui,Luiseño,http://id.loc.gov/vocabulary/languages/lui
-language,lun,Lunda,http://id.loc.gov/vocabulary/languages/lun
-language,luo,Luo (Kenya and Tanzania),http://id.loc.gov/vocabulary/languages/luo
-language,lus,Lushai,http://id.loc.gov/vocabulary/languages/lus
-language,mac,Macedonian,http://id.loc.gov/vocabulary/languages/mac
-language,mad,Madurese,http://id.loc.gov/vocabulary/languages/mad
-language,mag,Magahi,http://id.loc.gov/vocabulary/languages/mag
-language,mah,Marshallese,http://id.loc.gov/vocabulary/languages/mah
-language,mai,Maithili,http://id.loc.gov/vocabulary/languages/mai
-language,mak,Makasar,http://id.loc.gov/vocabulary/languages/mak
-language,mal,Malayalam,http://id.loc.gov/vocabulary/languages/mal
-language,man,Mandingo,http://id.loc.gov/vocabulary/languages/man
-language,mao,Maori,http://id.loc.gov/vocabulary/languages/mao
-language,map,Austronesian (Other),http://id.loc.gov/vocabulary/languages/map
-language,mar,Marathi,http://id.loc.gov/vocabulary/languages/mar
-language,mas,Maasai,http://id.loc.gov/vocabulary/languages/mas
-language,may,Malay,http://id.loc.gov/vocabulary/languages/may
-language,mdf,Moksha,http://id.loc.gov/vocabulary/languages/mdf
-language,mdr,Mandar,http://id.loc.gov/vocabulary/languages/mdr
-language,men,Mende,http://id.loc.gov/vocabulary/languages/men
-language,mga,"Irish, Middle (ca. 1100-1550)",http://id.loc.gov/vocabulary/languages/mga
-language,mic,Micmac,http://id.loc.gov/vocabulary/languages/mic
-language,min,Minangkabau,http://id.loc.gov/vocabulary/languages/min
-language,mis,Miscellaneous languages,http://id.loc.gov/vocabulary/languages/mis
-language,mkh,Mon-Khmer (Other),http://id.loc.gov/vocabulary/languages/mkh
-language,mlg,Malagasy,http://id.loc.gov/vocabulary/languages/mlg
-language,mlt,Maltese,http://id.loc.gov/vocabulary/languages/mlt
-language,mnc,Manchu,http://id.loc.gov/vocabulary/languages/mnc
-language,mni,Manipuri,http://id.loc.gov/vocabulary/languages/mni
-language,mno,Manobo languages,http://id.loc.gov/vocabulary/languages/mno
-language,moh,Mohawk,http://id.loc.gov/vocabulary/languages/moh
-language,mon,Mongolian,http://id.loc.gov/vocabulary/languages/mon
-language,mos,Mooré,http://id.loc.gov/vocabulary/languages/mos
-language,mul,Multiple languages,http://id.loc.gov/vocabulary/languages/mul
-language,mun,Munda (Other),http://id.loc.gov/vocabulary/languages/mun
-language,mus,Creek,http://id.loc.gov/vocabulary/languages/mus
-language,mwl,Mirandese,http://id.loc.gov/vocabulary/languages/mwl
-language,mwr,Marwari,http://id.loc.gov/vocabulary/languages/mwr
-language,myn,Mayan languages,http://id.loc.gov/vocabulary/languages/myn
-language,myv,Erzya,http://id.loc.gov/vocabulary/languages/myv
-language,nah,Nahuatl,http://id.loc.gov/vocabulary/languages/nah
-language,nai,North American Indian (Other),http://id.loc.gov/vocabulary/languages/nai
-language,nap,Neapolitan Italian,http://id.loc.gov/vocabulary/languages/nap
-language,nau,Nauru,http://id.loc.gov/vocabulary/languages/nau
-language,nav,Navajo,http://id.loc.gov/vocabulary/languages/nav
-language,nbl,Ndebele (South Africa),http://id.loc.gov/vocabulary/languages/nbl
-language,nde,Ndebele (Zimbabwe),http://id.loc.gov/vocabulary/languages/nde
-language,ndo,Ndonga,http://id.loc.gov/vocabulary/languages/ndo
-language,nds,Low German,http://id.loc.gov/vocabulary/languages/nds
-language,nep,Nepali,http://id.loc.gov/vocabulary/languages/nep
-language,new,Newari,http://id.loc.gov/vocabulary/languages/new
-language,nia,Nias,http://id.loc.gov/vocabulary/languages/nia
-language,nic,Niger-Kordofanian (Other),http://id.loc.gov/vocabulary/languages/nic
-language,niu,Niuean,http://id.loc.gov/vocabulary/languages/niu
-language,nno,Norwegian (Nynorsk),http://id.loc.gov/vocabulary/languages/nno
-language,nob,Norwegian (Bokmål),http://id.loc.gov/vocabulary/languages/nob
-language,nog,Nogai,http://id.loc.gov/vocabulary/languages/nog
-language,non,Old Norse,http://id.loc.gov/vocabulary/languages/non
-language,nor,Norwegian,http://id.loc.gov/vocabulary/languages/nor
-language,nqo,N'Ko,http://id.loc.gov/vocabulary/languages/nqo
-language,nso,Northern Sotho,http://id.loc.gov/vocabulary/languages/nso
-language,nub,Nubian languages,http://id.loc.gov/vocabulary/languages/nub
-language,nwc,"Newari, Old",http://id.loc.gov/vocabulary/languages/nwc
-language,nya,Nyanja,http://id.loc.gov/vocabulary/languages/nya
-language,nym,Nyamwezi,http://id.loc.gov/vocabulary/languages/nym
-language,nyn,Nyankole,http://id.loc.gov/vocabulary/languages/nyn
-language,nyo,Nyoro,http://id.loc.gov/vocabulary/languages/nyo
-language,nzi,Nzima,http://id.loc.gov/vocabulary/languages/nzi
-language,oci,Occitan (post-1500),http://id.loc.gov/vocabulary/languages/oci
-language,oji,Ojibwa,http://id.loc.gov/vocabulary/languages/oji
-language,ori,Oriya,http://id.loc.gov/vocabulary/languages/ori
-language,orm,Oromo,http://id.loc.gov/vocabulary/languages/orm
-language,osa,Osage,http://id.loc.gov/vocabulary/languages/osa
-language,oss,Ossetic,http://id.loc.gov/vocabulary/languages/oss
-language,ota,"Turkish, Ottoman",http://id.loc.gov/vocabulary/languages/ota
-language,oto,Otomian languages,http://id.loc.gov/vocabulary/languages/oto
-language,paa,Papuan (Other),http://id.loc.gov/vocabulary/languages/paa
-language,pag,Pangasinan,http://id.loc.gov/vocabulary/languages/pag
-language,pal,Pahlavi,http://id.loc.gov/vocabulary/languages/pal
-language,pam,Pampanga,http://id.loc.gov/vocabulary/languages/pam
-language,pan,Panjabi,http://id.loc.gov/vocabulary/languages/pan
-language,pap,Papiamento,http://id.loc.gov/vocabulary/languages/pap
-language,pau,Palauan,http://id.loc.gov/vocabulary/languages/pau
-language,peo,Old Persian (ca. 600-400 B.C.),http://id.loc.gov/vocabulary/languages/peo
-language,per,Persian,http://id.loc.gov/vocabulary/languages/per
-language,phi,Philippine (Other),http://id.loc.gov/vocabulary/languages/phi
-language,phn,Phoenician,http://id.loc.gov/vocabulary/languages/phn
-language,pli,Pali,http://id.loc.gov/vocabulary/languages/pli
-language,pol,Polish,http://id.loc.gov/vocabulary/languages/pol
-language,pon,Pohnpeian,http://id.loc.gov/vocabulary/languages/pon
-language,por,Portuguese,http://id.loc.gov/vocabulary/languages/por
-language,pra,Prakrit languages,http://id.loc.gov/vocabulary/languages/pra
-language,pro,Provençal (to 1500),http://id.loc.gov/vocabulary/languages/pro
-language,pus,Pushto,http://id.loc.gov/vocabulary/languages/pus
-language,que,Quechua,http://id.loc.gov/vocabulary/languages/que
-language,raj,Rajasthani,http://id.loc.gov/vocabulary/languages/raj
-language,rap,Rapanui,http://id.loc.gov/vocabulary/languages/rap
-language,rar,Rarotongan,http://id.loc.gov/vocabulary/languages/rar
-language,roa,Romance (Other),http://id.loc.gov/vocabulary/languages/roa
-language,roh,Raeto-Romance,http://id.loc.gov/vocabulary/languages/roh
-language,rom,Romani,http://id.loc.gov/vocabulary/languages/rom
-language,rum,Romanian,http://id.loc.gov/vocabulary/languages/rum
-language,run,Rundi,http://id.loc.gov/vocabulary/languages/run
-language,rup,Aromanian,http://id.loc.gov/vocabulary/languages/rup
-language,rus,Russian,http://id.loc.gov/vocabulary/languages/rus
-language,sad,Sandawe,http://id.loc.gov/vocabulary/languages/sad
-language,sag,Sango (Ubangi Creole),http://id.loc.gov/vocabulary/languages/sag
-language,sah,Yakut,http://id.loc.gov/vocabulary/languages/sah
-language,sai,South American Indian (Other),http://id.loc.gov/vocabulary/languages/sai
-language,sal,Salishan languages,http://id.loc.gov/vocabulary/languages/sal
-language,sam,Samaritan Aramaic,http://id.loc.gov/vocabulary/languages/sam
-language,san,Sanskrit,http://id.loc.gov/vocabulary/languages/san
-language,sas,Sasak,http://id.loc.gov/vocabulary/languages/sas
-language,sat,Santali,http://id.loc.gov/vocabulary/languages/sat
-language,scn,Sicilian Italian,http://id.loc.gov/vocabulary/languages/scn
-language,sco,Scots,http://id.loc.gov/vocabulary/languages/sco
-language,sel,Selkup,http://id.loc.gov/vocabulary/languages/sel
-language,sem,Semitic (Other),http://id.loc.gov/vocabulary/languages/sem
-language,sga,"Irish, Old (to 1100)",http://id.loc.gov/vocabulary/languages/sga
-language,sgn,Sign languages,http://id.loc.gov/vocabulary/languages/sgn
-language,shn,Shan,http://id.loc.gov/vocabulary/languages/shn
-language,sid,Sidamo,http://id.loc.gov/vocabulary/languages/sid
-language,sin,Sinhalese,http://id.loc.gov/vocabulary/languages/sin
-language,sio,Siouan (Other),http://id.loc.gov/vocabulary/languages/sio
-language,sit,Sino-Tibetan (Other),http://id.loc.gov/vocabulary/languages/sit
-language,sla,Slavic (Other),http://id.loc.gov/vocabulary/languages/sla
-language,slo,Slovak,http://id.loc.gov/vocabulary/languages/slo
-language,slv,Slovenian,http://id.loc.gov/vocabulary/languages/slv
-language,sma,Southern Sami,http://id.loc.gov/vocabulary/languages/sma
-language,sme,Northern Sami,http://id.loc.gov/vocabulary/languages/sme
-language,smi,Sami,http://id.loc.gov/vocabulary/languages/smi
-language,smj,Lule Sami,http://id.loc.gov/vocabulary/languages/smj
-language,smn,Inari Sami,http://id.loc.gov/vocabulary/languages/smn
-language,smo,Samoan,http://id.loc.gov/vocabulary/languages/smo
-language,sms,Skolt Sami,http://id.loc.gov/vocabulary/languages/sms
-language,sna,Shona,http://id.loc.gov/vocabulary/languages/sna
-language,snd,Sindhi,http://id.loc.gov/vocabulary/languages/snd
-language,snk,Soninke,http://id.loc.gov/vocabulary/languages/snk
-language,sog,Sogdian,http://id.loc.gov/vocabulary/languages/sog
-language,som,Somali,http://id.loc.gov/vocabulary/languages/som
-language,son,Songhai,http://id.loc.gov/vocabulary/languages/son
-language,sot,Sotho,http://id.loc.gov/vocabulary/languages/sot
-language,spa,Spanish,http://id.loc.gov/vocabulary/languages/spa
-language,srd,Sardinian,http://id.loc.gov/vocabulary/languages/srd
-language,srn,Sranan,http://id.loc.gov/vocabulary/languages/srn
-language,srp,Serbian,http://id.loc.gov/vocabulary/languages/srp
-language,srr,Serer,http://id.loc.gov/vocabulary/languages/srr
-language,ssa,Nilo-Saharan (Other),http://id.loc.gov/vocabulary/languages/ssa
-language,ssw,Swazi,http://id.loc.gov/vocabulary/languages/ssw
-language,suk,Sukuma,http://id.loc.gov/vocabulary/languages/suk
-language,sun,Sundanese,http://id.loc.gov/vocabulary/languages/sun
-language,sus,Susu,http://id.loc.gov/vocabulary/languages/sus
-language,sux,Sumerian,http://id.loc.gov/vocabulary/languages/sux
-language,swa,Swahili,http://id.loc.gov/vocabulary/languages/swa
-language,swe,Swedish,http://id.loc.gov/vocabulary/languages/swe
-language,syc,Syriac,http://id.loc.gov/vocabulary/languages/syc
-language,syr,"Syriac, Modern",http://id.loc.gov/vocabulary/languages/syr
-language,tah,Tahitian,http://id.loc.gov/vocabulary/languages/tah
-language,tai,Tai (Other),http://id.loc.gov/vocabulary/languages/tai
-language,tam,Tamil,http://id.loc.gov/vocabulary/languages/tam
-language,tat,Tatar,http://id.loc.gov/vocabulary/languages/tat
-language,tel,Telugu,http://id.loc.gov/vocabulary/languages/tel
-language,tem,Temne,http://id.loc.gov/vocabulary/languages/tem
-language,ter,Terena,http://id.loc.gov/vocabulary/languages/ter
-language,tet,Tetum,http://id.loc.gov/vocabulary/languages/tet
-language,tgk,Tajik,http://id.loc.gov/vocabulary/languages/tgk
-language,tgl,Tagalog,http://id.loc.gov/vocabulary/languages/tgl
-language,tha,Thai,http://id.loc.gov/vocabulary/languages/tha
-language,tib,Tibetan,http://id.loc.gov/vocabulary/languages/tib
-language,tig,Tigré,http://id.loc.gov/vocabulary/languages/tig
-language,tir,Tigrinya,http://id.loc.gov/vocabulary/languages/tir
-language,tiv,Tiv,http://id.loc.gov/vocabulary/languages/tiv
-language,tkl,Tokelauan,http://id.loc.gov/vocabulary/languages/tkl
-language,tlh,Klingon (Artificial language),http://id.loc.gov/vocabulary/languages/tlh
-language,tli,Tlingit,http://id.loc.gov/vocabulary/languages/tli
-language,tmh,Tamashek,http://id.loc.gov/vocabulary/languages/tmh
-language,tog,Tonga (Nyasa),http://id.loc.gov/vocabulary/languages/tog
-language,ton,Tongan,http://id.loc.gov/vocabulary/languages/ton
-language,tpi,Tok Pisin,http://id.loc.gov/vocabulary/languages/tpi
-language,tsi,Tsimshian,http://id.loc.gov/vocabulary/languages/tsi
-language,tsn,Tswana,http://id.loc.gov/vocabulary/languages/tsn
-language,tso,Tsonga,http://id.loc.gov/vocabulary/languages/tso
-language,tuk,Turkmen,http://id.loc.gov/vocabulary/languages/tuk
-language,tum,Tumbuka,http://id.loc.gov/vocabulary/languages/tum
-language,tup,Tupi languages,http://id.loc.gov/vocabulary/languages/tup
-language,tur,Turkish,http://id.loc.gov/vocabulary/languages/tur
-language,tut,Altaic (Other),http://id.loc.gov/vocabulary/languages/tut
-language,tvl,Tuvaluan,http://id.loc.gov/vocabulary/languages/tvl
-language,twi,Twi,http://id.loc.gov/vocabulary/languages/twi
-language,tyv,Tuvinian,http://id.loc.gov/vocabulary/languages/tyv
-language,udm,Udmurt,http://id.loc.gov/vocabulary/languages/udm
-language,uga,Ugaritic,http://id.loc.gov/vocabulary/languages/uga
-language,uig,Uighur,http://id.loc.gov/vocabulary/languages/uig
-language,ukr,Ukrainian,http://id.loc.gov/vocabulary/languages/ukr
-language,umb,Umbundu,http://id.loc.gov/vocabulary/languages/umb
-language,und,Undetermined,http://id.loc.gov/vocabulary/languages/und
-language,urd,Urdu,http://id.loc.gov/vocabulary/languages/urd
-language,uzb,Uzbek,http://id.loc.gov/vocabulary/languages/uzb
-language,vai,Vai,http://id.loc.gov/vocabulary/languages/vai
-language,ven,Venda,http://id.loc.gov/vocabulary/languages/ven
-language,vie,Vietnamese,http://id.loc.gov/vocabulary/languages/vie
-language,vol,Volapük,http://id.loc.gov/vocabulary/languages/vol
-language,vot,Votic,http://id.loc.gov/vocabulary/languages/vot
-language,wak,Wakashan languages,http://id.loc.gov/vocabulary/languages/wak
-language,wal,Wolayta,http://id.loc.gov/vocabulary/languages/wal
-language,war,Waray,http://id.loc.gov/vocabulary/languages/war
-language,was,Washoe,http://id.loc.gov/vocabulary/languages/was
-language,wel,Welsh,http://id.loc.gov/vocabulary/languages/wel
-language,wen,Sorbian (Other),http://id.loc.gov/vocabulary/languages/wen
-language,wln,Walloon,http://id.loc.gov/vocabulary/languages/wln
-language,wol,Wolof,http://id.loc.gov/vocabulary/languages/wol
-language,xal,Oirat,http://id.loc.gov/vocabulary/languages/xal
-language,xho,Xhosa,http://id.loc.gov/vocabulary/languages/xho
-language,yao,Yao (Africa),http://id.loc.gov/vocabulary/languages/yao
-language,yap,Yapese,http://id.loc.gov/vocabulary/languages/yap
-language,yid,Yiddish,http://id.loc.gov/vocabulary/languages/yid
-language,yor,Yoruba,http://id.loc.gov/vocabulary/languages/yor
-language,ypk,Yupik languages,http://id.loc.gov/vocabulary/languages/ypk
-language,zap,Zapotec,http://id.loc.gov/vocabulary/languages/zap
-language,zbl,Blissymbolics,http://id.loc.gov/vocabulary/languages/zbl
-language,zen,Zenaga,http://id.loc.gov/vocabulary/languages/zen
-language,zha,Zhuang,http://id.loc.gov/vocabulary/languages/zha
-language,znd,Zande languages,http://id.loc.gov/vocabulary/languages/znd
-language,zul,Zulu,http://id.loc.gov/vocabulary/languages/zul
-language,zun,Zuni,http://id.loc.gov/vocabulary/languages/zun
-language,zxx,No linguistic content,http://id.loc.gov/vocabulary/languages/zxx
-language,zza,Zaza,http://id.loc.gov/vocabulary/languages/zza
+vid,code,name,uri,code_2digit
+language,aar,Afar,http://id.loc.gov/vocabulary/languages/aar,
+language,abk,Abkhaz,http://id.loc.gov/vocabulary/languages/abk,
+language,ace,Achinese,http://id.loc.gov/vocabulary/languages/ace,
+language,ach,Acoli,http://id.loc.gov/vocabulary/languages/ach,
+language,ada,Adangme,http://id.loc.gov/vocabulary/languages/ada,
+language,ady,Adygei,http://id.loc.gov/vocabulary/languages/ady,
+language,afa,Afroasiatic (Other),http://id.loc.gov/vocabulary/languages/afa,
+language,afh,Afrihili (Artificial language),http://id.loc.gov/vocabulary/languages/afh,
+language,afr,Afrikaans,http://id.loc.gov/vocabulary/languages/afr,
+language,ain,Ainu,http://id.loc.gov/vocabulary/languages/ain,
+language,aka,Akan,http://id.loc.gov/vocabulary/languages/aka,
+language,akk,Akkadian,http://id.loc.gov/vocabulary/languages/akk,
+language,alb,Albanian,http://id.loc.gov/vocabulary/languages/alb,
+language,ale,Aleut,http://id.loc.gov/vocabulary/languages/ale,
+language,alg,Algonquian (Other),http://id.loc.gov/vocabulary/languages/alg,
+language,alt,Altai,http://id.loc.gov/vocabulary/languages/alt,
+language,amh,Amharic,http://id.loc.gov/vocabulary/languages/amh,
+language,ang,"English, Old (ca. 450-1100)",http://id.loc.gov/vocabulary/languages/ang,
+language,anp,Angika,http://id.loc.gov/vocabulary/languages/anp,
+language,apa,Apache languages,http://id.loc.gov/vocabulary/languages/apa,
+language,ara,Arabic,http://id.loc.gov/vocabulary/languages/ara,
+language,arc,Aramaic,http://id.loc.gov/vocabulary/languages/arc,
+language,arg,Aragonese,http://id.loc.gov/vocabulary/languages/arg,
+language,arm,Armenian,http://id.loc.gov/vocabulary/languages/arm,
+language,arn,Mapuche,http://id.loc.gov/vocabulary/languages/arn,
+language,arp,Arapaho,http://id.loc.gov/vocabulary/languages/arp,
+language,art,Artificial (Other),http://id.loc.gov/vocabulary/languages/art,
+language,arw,Arawak,http://id.loc.gov/vocabulary/languages/arw,
+language,asm,Assamese,http://id.loc.gov/vocabulary/languages/asm,
+language,ast,Bable,http://id.loc.gov/vocabulary/languages/ast,
+language,ath,Athapascan (Other),http://id.loc.gov/vocabulary/languages/ath,
+language,aus,Australian languages,http://id.loc.gov/vocabulary/languages/aus,
+language,ava,Avaric,http://id.loc.gov/vocabulary/languages/ava,
+language,ave,Avestan,http://id.loc.gov/vocabulary/languages/ave,
+language,awa,Awadhi,http://id.loc.gov/vocabulary/languages/awa,
+language,aym,Aymara,http://id.loc.gov/vocabulary/languages/aym,
+language,aze,Azerbaijani,http://id.loc.gov/vocabulary/languages/aze,
+language,bad,Banda languages,http://id.loc.gov/vocabulary/languages/bad,
+language,bai,Bamileke languages,http://id.loc.gov/vocabulary/languages/bai,
+language,bak,Bashkir,http://id.loc.gov/vocabulary/languages/bak,
+language,bal,Baluchi,http://id.loc.gov/vocabulary/languages/bal,
+language,bam,Bambara,http://id.loc.gov/vocabulary/languages/bam,
+language,ban,Balinese,http://id.loc.gov/vocabulary/languages/ban,
+language,baq,Basque,http://id.loc.gov/vocabulary/languages/baq,
+language,bas,Basa,http://id.loc.gov/vocabulary/languages/bas,
+language,bat,Baltic (Other),http://id.loc.gov/vocabulary/languages/bat,
+language,bej,Beja,http://id.loc.gov/vocabulary/languages/bej,
+language,bel,Belarusian,http://id.loc.gov/vocabulary/languages/bel,
+language,bem,Bemba,http://id.loc.gov/vocabulary/languages/bem,
+language,ben,Bengali,http://id.loc.gov/vocabulary/languages/ben,
+language,ber,Berber (Other),http://id.loc.gov/vocabulary/languages/ber,
+language,bho,Bhojpuri,http://id.loc.gov/vocabulary/languages/bho,
+language,bih,Bihari (Other),http://id.loc.gov/vocabulary/languages/bih,
+language,bik,Bikol,http://id.loc.gov/vocabulary/languages/bik,
+language,bin,Edo,http://id.loc.gov/vocabulary/languages/bin,
+language,bis,Bislama,http://id.loc.gov/vocabulary/languages/bis,
+language,bla,Siksika,http://id.loc.gov/vocabulary/languages/bla,
+language,bnt,Bantu (Other),http://id.loc.gov/vocabulary/languages/bnt,
+language,bos,Bosnian,http://id.loc.gov/vocabulary/languages/bos,
+language,bra,Braj,http://id.loc.gov/vocabulary/languages/bra,
+language,bre,Breton,http://id.loc.gov/vocabulary/languages/bre,
+language,btk,Batak,http://id.loc.gov/vocabulary/languages/btk,
+language,bua,Buriat,http://id.loc.gov/vocabulary/languages/bua,
+language,bug,Bugis,http://id.loc.gov/vocabulary/languages/bug,
+language,bul,Bulgarian,http://id.loc.gov/vocabulary/languages/bul,
+language,bur,Burmese,http://id.loc.gov/vocabulary/languages/bur,
+language,byn,Bilin,http://id.loc.gov/vocabulary/languages/byn,
+language,cad,Caddo,http://id.loc.gov/vocabulary/languages/cad,
+language,cai,Central American Indian (Other),http://id.loc.gov/vocabulary/languages/cai,
+language,car,Carib,http://id.loc.gov/vocabulary/languages/car,
+language,cat,Catalan,http://id.loc.gov/vocabulary/languages/cat,
+language,cau,Caucasian (Other),http://id.loc.gov/vocabulary/languages/cau,
+language,ceb,Cebuano,http://id.loc.gov/vocabulary/languages/ceb,
+language,cel,Celtic (Other),http://id.loc.gov/vocabulary/languages/cel,
+language,cha,Chamorro,http://id.loc.gov/vocabulary/languages/cha,
+language,chb,Chibcha,http://id.loc.gov/vocabulary/languages/chb,
+language,che,Chechen,http://id.loc.gov/vocabulary/languages/che,
+language,chg,Chagatai,http://id.loc.gov/vocabulary/languages/chg,
+language,chi,Chinese,http://id.loc.gov/vocabulary/languages/chi,
+language,chk,Chuukese,http://id.loc.gov/vocabulary/languages/chk,
+language,chm,Mari,http://id.loc.gov/vocabulary/languages/chm,
+language,chn,Chinook jargon,http://id.loc.gov/vocabulary/languages/chn,
+language,cho,Choctaw,http://id.loc.gov/vocabulary/languages/cho,
+language,chp,Chipewyan,http://id.loc.gov/vocabulary/languages/chp,
+language,chr,Cherokee,http://id.loc.gov/vocabulary/languages/chr,
+language,chu,Church Slavic,http://id.loc.gov/vocabulary/languages/chu,
+language,chv,Chuvash,http://id.loc.gov/vocabulary/languages/chv,
+language,chy,Cheyenne,http://id.loc.gov/vocabulary/languages/chy,
+language,cmc,Chamic languages,http://id.loc.gov/vocabulary/languages/cmc,
+language,cnr,Montenegrin,http://id.loc.gov/vocabulary/languages/cnr,
+language,cop,Coptic,http://id.loc.gov/vocabulary/languages/cop,
+language,cor,Cornish,http://id.loc.gov/vocabulary/languages/cor,
+language,cos,Corsican,http://id.loc.gov/vocabulary/languages/cos,
+language,cpe,"Creoles and Pidgins, English-based (Other)",http://id.loc.gov/vocabulary/languages/cpe,
+language,cpf,"Creoles and Pidgins, French-based (Other)",http://id.loc.gov/vocabulary/languages/cpf,
+language,cpp,"Creoles and Pidgins, Portuguese-based (Other)",http://id.loc.gov/vocabulary/languages/cpp,
+language,cre,Cree,http://id.loc.gov/vocabulary/languages/cre,
+language,crh,Crimean Tatar,http://id.loc.gov/vocabulary/languages/crh,
+language,crp,Creoles and Pidgins (Other),http://id.loc.gov/vocabulary/languages/crp,
+language,csb,Kashubian,http://id.loc.gov/vocabulary/languages/csb,
+language,cus,Cushitic (Other),http://id.loc.gov/vocabulary/languages/cus,
+language,cze,Czech,http://id.loc.gov/vocabulary/languages/cze,
+language,dak,Dakota,http://id.loc.gov/vocabulary/languages/dak,
+language,dan,Danish,http://id.loc.gov/vocabulary/languages/dan,
+language,dar,Dargwa,http://id.loc.gov/vocabulary/languages/dar,
+language,day,Dayak,http://id.loc.gov/vocabulary/languages/day,
+language,del,Delaware,http://id.loc.gov/vocabulary/languages/del,
+language,den,Slavey,http://id.loc.gov/vocabulary/languages/den,
+language,dgr,Dogrib,http://id.loc.gov/vocabulary/languages/dgr,
+language,din,Dinka,http://id.loc.gov/vocabulary/languages/din,
+language,div,Divehi,http://id.loc.gov/vocabulary/languages/div,
+language,doi,Dogri,http://id.loc.gov/vocabulary/languages/doi,
+language,dra,Dravidian (Other),http://id.loc.gov/vocabulary/languages/dra,
+language,dsb,Lower Sorbian,http://id.loc.gov/vocabulary/languages/dsb,
+language,dua,Duala,http://id.loc.gov/vocabulary/languages/dua,
+language,dum,"Dutch, Middle (ca. 1050-1350)",http://id.loc.gov/vocabulary/languages/dum,
+language,dut,Dutch,http://id.loc.gov/vocabulary/languages/dut,
+language,dyu,Dyula,http://id.loc.gov/vocabulary/languages/dyu,
+language,dzo,Dzongkha,http://id.loc.gov/vocabulary/languages/dzo,
+language,efi,Efik,http://id.loc.gov/vocabulary/languages/efi,
+language,egy,Egyptian,http://id.loc.gov/vocabulary/languages/egy,
+language,eka,Ekajuk,http://id.loc.gov/vocabulary/languages/eka,
+language,elx,Elamite,http://id.loc.gov/vocabulary/languages/elx,
+language,eng,English,http://id.loc.gov/vocabulary/languages/eng,en
+language,enm,"English, Middle (1100-1500)",http://id.loc.gov/vocabulary/languages/enm,en
+language,epo,Esperanto,http://id.loc.gov/vocabulary/languages/epo,
+language,est,Estonian,http://id.loc.gov/vocabulary/languages/est,
+language,ewe,Ewe,http://id.loc.gov/vocabulary/languages/ewe,
+language,ewo,Ewondo,http://id.loc.gov/vocabulary/languages/ewo,
+language,fan,Fang,http://id.loc.gov/vocabulary/languages/fan,
+language,fao,Faroese,http://id.loc.gov/vocabulary/languages/fao,
+language,fat,Fanti,http://id.loc.gov/vocabulary/languages/fat,
+language,fij,Fijian,http://id.loc.gov/vocabulary/languages/fij,
+language,fil,Filipino,http://id.loc.gov/vocabulary/languages/fil,
+language,fin,Finnish,http://id.loc.gov/vocabulary/languages/fin,
+language,fiu,Finno-Ugrian (Other),http://id.loc.gov/vocabulary/languages/fiu,
+language,fon,Fon,http://id.loc.gov/vocabulary/languages/fon,
+language,fre,French,http://id.loc.gov/vocabulary/languages/fre,fr
+language,frm,"French, Middle (ca. 1300-1600)",http://id.loc.gov/vocabulary/languages/frm,fr
+language,fro,"French, Old (ca. 842-1300)",http://id.loc.gov/vocabulary/languages/fro,fr
+language,frr,North Frisian,http://id.loc.gov/vocabulary/languages/frr,
+language,frs,East Frisian,http://id.loc.gov/vocabulary/languages/frs,
+language,fry,Frisian,http://id.loc.gov/vocabulary/languages/fry,
+language,ful,Fula,http://id.loc.gov/vocabulary/languages/ful,
+language,fur,Friulian,http://id.loc.gov/vocabulary/languages/fur,
+language,gaa,Gã,http://id.loc.gov/vocabulary/languages/gaa,
+language,gay,Gayo,http://id.loc.gov/vocabulary/languages/gay,
+language,gba,Gbaya,http://id.loc.gov/vocabulary/languages/gba,
+language,gem,Germanic (Other),http://id.loc.gov/vocabulary/languages/gem,
+language,geo,Georgian,http://id.loc.gov/vocabulary/languages/geo,
+language,ger,German,http://id.loc.gov/vocabulary/languages/ger,
+language,gez,Ethiopic,http://id.loc.gov/vocabulary/languages/gez,
+language,gil,Gilbertese,http://id.loc.gov/vocabulary/languages/gil,
+language,gla,Scottish Gaelic,http://id.loc.gov/vocabulary/languages/gla,
+language,gle,Irish,http://id.loc.gov/vocabulary/languages/gle,
+language,glg,Galician,http://id.loc.gov/vocabulary/languages/glg,
+language,glv,Manx,http://id.loc.gov/vocabulary/languages/glv,
+language,gmh,"German, Middle High (ca. 1050-1500)",http://id.loc.gov/vocabulary/languages/gmh,
+language,goh,"German, Old High (ca. 750-1050)",http://id.loc.gov/vocabulary/languages/goh,
+language,gon,Gondi,http://id.loc.gov/vocabulary/languages/gon,
+language,gor,Gorontalo,http://id.loc.gov/vocabulary/languages/gor,
+language,got,Gothic,http://id.loc.gov/vocabulary/languages/got,
+language,grb,Grebo,http://id.loc.gov/vocabulary/languages/grb,
+language,grc,"Greek, Ancient (to 1453)",http://id.loc.gov/vocabulary/languages/grc,
+language,gre,"Greek, Modern (1453-)",http://id.loc.gov/vocabulary/languages/gre,
+language,grn,Guarani,http://id.loc.gov/vocabulary/languages/grn,
+language,gsw,Swiss German,http://id.loc.gov/vocabulary/languages/gsw,
+language,guj,Gujarati,http://id.loc.gov/vocabulary/languages/guj,
+language,gwi,Gwich'in,http://id.loc.gov/vocabulary/languages/gwi,
+language,hai,Haida,http://id.loc.gov/vocabulary/languages/hai,
+language,hat,Haitian French Creole,http://id.loc.gov/vocabulary/languages/hat,
+language,hau,Hausa,http://id.loc.gov/vocabulary/languages/hau,
+language,haw,Hawaiian,http://id.loc.gov/vocabulary/languages/haw,
+language,heb,Hebrew,http://id.loc.gov/vocabulary/languages/heb,
+language,her,Herero,http://id.loc.gov/vocabulary/languages/her,
+language,hil,Hiligaynon,http://id.loc.gov/vocabulary/languages/hil,
+language,him,Western Pahari languages,http://id.loc.gov/vocabulary/languages/him,
+language,hin,Hindi,http://id.loc.gov/vocabulary/languages/hin,
+language,hit,Hittite,http://id.loc.gov/vocabulary/languages/hit,
+language,hmn,Hmong,http://id.loc.gov/vocabulary/languages/hmn,
+language,hmo,Hiri Motu,http://id.loc.gov/vocabulary/languages/hmo,
+language,hrv,Croatian,http://id.loc.gov/vocabulary/languages/hrv,
+language,hsb,Upper Sorbian,http://id.loc.gov/vocabulary/languages/hsb,
+language,hun,Hungarian,http://id.loc.gov/vocabulary/languages/hun,
+language,hup,Hupa,http://id.loc.gov/vocabulary/languages/hup,
+language,iba,Iban,http://id.loc.gov/vocabulary/languages/iba,
+language,ibo,Igbo,http://id.loc.gov/vocabulary/languages/ibo,
+language,ice,Icelandic,http://id.loc.gov/vocabulary/languages/ice,
+language,ido,Ido,http://id.loc.gov/vocabulary/languages/ido,
+language,iii,Sichuan Yi,http://id.loc.gov/vocabulary/languages/iii,
+language,ijo,Ijo,http://id.loc.gov/vocabulary/languages/ijo,
+language,iku,Inuktitut,http://id.loc.gov/vocabulary/languages/iku,
+language,ile,Interlingue,http://id.loc.gov/vocabulary/languages/ile,
+language,ilo,Iloko,http://id.loc.gov/vocabulary/languages/ilo,
+language,ina,Interlingua (International Auxiliary Language Association),http://id.loc.gov/vocabulary/languages/ina,
+language,inc,Indic (Other),http://id.loc.gov/vocabulary/languages/inc,
+language,ind,Indonesian,http://id.loc.gov/vocabulary/languages/ind,
+language,ine,Indo-European (Other),http://id.loc.gov/vocabulary/languages/ine,
+language,inh,Ingush,http://id.loc.gov/vocabulary/languages/inh,
+language,ipk,Inupiaq,http://id.loc.gov/vocabulary/languages/ipk,
+language,ira,Iranian (Other),http://id.loc.gov/vocabulary/languages/ira,
+language,iro,Iroquoian (Other),http://id.loc.gov/vocabulary/languages/iro,
+language,ita,Italian,http://id.loc.gov/vocabulary/languages/ita,
+language,jav,Javanese,http://id.loc.gov/vocabulary/languages/jav,
+language,jbo,Lojban (Artificial language),http://id.loc.gov/vocabulary/languages/jbo,
+language,jpn,Japanese,http://id.loc.gov/vocabulary/languages/jpn,
+language,jpr,Judeo-Persian,http://id.loc.gov/vocabulary/languages/jpr,
+language,jrb,Judeo-Arabic,http://id.loc.gov/vocabulary/languages/jrb,
+language,kaa,Kara-Kalpak,http://id.loc.gov/vocabulary/languages/kaa,
+language,kab,Kabyle,http://id.loc.gov/vocabulary/languages/kab,
+language,kac,Kachin,http://id.loc.gov/vocabulary/languages/kac,
+language,kal,Kalâtdlisut,http://id.loc.gov/vocabulary/languages/kal,
+language,kam,Kamba,http://id.loc.gov/vocabulary/languages/kam,
+language,kan,Kannada,http://id.loc.gov/vocabulary/languages/kan,
+language,kar,Karen languages,http://id.loc.gov/vocabulary/languages/kar,
+language,kas,Kashmiri,http://id.loc.gov/vocabulary/languages/kas,
+language,kau,Kanuri,http://id.loc.gov/vocabulary/languages/kau,
+language,kaw,Kawi,http://id.loc.gov/vocabulary/languages/kaw,
+language,kaz,Kazakh,http://id.loc.gov/vocabulary/languages/kaz,
+language,kbd,Kabardian,http://id.loc.gov/vocabulary/languages/kbd,
+language,kha,Khasi,http://id.loc.gov/vocabulary/languages/kha,
+language,khi,Khoisan (Other),http://id.loc.gov/vocabulary/languages/khi,
+language,khm,Khmer,http://id.loc.gov/vocabulary/languages/khm,
+language,kho,Khotanese,http://id.loc.gov/vocabulary/languages/kho,
+language,kik,Kikuyu,http://id.loc.gov/vocabulary/languages/kik,
+language,kin,Kinyarwanda,http://id.loc.gov/vocabulary/languages/kin,
+language,kir,Kyrgyz,http://id.loc.gov/vocabulary/languages/kir,
+language,kmb,Kimbundu,http://id.loc.gov/vocabulary/languages/kmb,
+language,kok,Konkani,http://id.loc.gov/vocabulary/languages/kok,
+language,kom,Komi,http://id.loc.gov/vocabulary/languages/kom,
+language,kon,Kongo,http://id.loc.gov/vocabulary/languages/kon,
+language,kor,Korean,http://id.loc.gov/vocabulary/languages/kor,
+language,kos,Kosraean,http://id.loc.gov/vocabulary/languages/kos,
+language,kpe,Kpelle,http://id.loc.gov/vocabulary/languages/kpe,
+language,krc,Karachay-Balkar,http://id.loc.gov/vocabulary/languages/krc,
+language,krl,Karelian,http://id.loc.gov/vocabulary/languages/krl,
+language,kro,Kru (Other),http://id.loc.gov/vocabulary/languages/kro,
+language,kru,Kurukh,http://id.loc.gov/vocabulary/languages/kru,
+language,kua,Kuanyama,http://id.loc.gov/vocabulary/languages/kua,
+language,kum,Kumyk,http://id.loc.gov/vocabulary/languages/kum,
+language,kur,Kurdish,http://id.loc.gov/vocabulary/languages/kur,
+language,kut,Kootenai,http://id.loc.gov/vocabulary/languages/kut,
+language,lad,Ladino,http://id.loc.gov/vocabulary/languages/lad,
+language,lah,Lahndā,http://id.loc.gov/vocabulary/languages/lah,
+language,lam,Lamba (Zambia and Congo),http://id.loc.gov/vocabulary/languages/lam,
+language,lao,Lao,http://id.loc.gov/vocabulary/languages/lao,
+language,lat,Latin,http://id.loc.gov/vocabulary/languages/lat,
+language,lav,Latvian,http://id.loc.gov/vocabulary/languages/lav,
+language,lez,Lezgian,http://id.loc.gov/vocabulary/languages/lez,
+language,lim,Limburgish,http://id.loc.gov/vocabulary/languages/lim,
+language,lin,Lingala,http://id.loc.gov/vocabulary/languages/lin,
+language,lit,Lithuanian,http://id.loc.gov/vocabulary/languages/lit,
+language,lol,Mongo-Nkundu,http://id.loc.gov/vocabulary/languages/lol,
+language,loz,Lozi,http://id.loc.gov/vocabulary/languages/loz,
+language,ltz,Luxembourgish,http://id.loc.gov/vocabulary/languages/ltz,
+language,lua,Luba-Lulua,http://id.loc.gov/vocabulary/languages/lua,
+language,lub,Luba-Katanga,http://id.loc.gov/vocabulary/languages/lub,
+language,lug,Ganda,http://id.loc.gov/vocabulary/languages/lug,
+language,lui,Luiseño,http://id.loc.gov/vocabulary/languages/lui,
+language,lun,Lunda,http://id.loc.gov/vocabulary/languages/lun,
+language,luo,Luo (Kenya and Tanzania),http://id.loc.gov/vocabulary/languages/luo,
+language,lus,Lushai,http://id.loc.gov/vocabulary/languages/lus,
+language,mac,Macedonian,http://id.loc.gov/vocabulary/languages/mac,
+language,mad,Madurese,http://id.loc.gov/vocabulary/languages/mad,
+language,mag,Magahi,http://id.loc.gov/vocabulary/languages/mag,
+language,mah,Marshallese,http://id.loc.gov/vocabulary/languages/mah,
+language,mai,Maithili,http://id.loc.gov/vocabulary/languages/mai,
+language,mak,Makasar,http://id.loc.gov/vocabulary/languages/mak,
+language,mal,Malayalam,http://id.loc.gov/vocabulary/languages/mal,
+language,man,Mandingo,http://id.loc.gov/vocabulary/languages/man,
+language,mao,Maori,http://id.loc.gov/vocabulary/languages/mao,
+language,map,Austronesian (Other),http://id.loc.gov/vocabulary/languages/map,
+language,mar,Marathi,http://id.loc.gov/vocabulary/languages/mar,
+language,mas,Maasai,http://id.loc.gov/vocabulary/languages/mas,
+language,may,Malay,http://id.loc.gov/vocabulary/languages/may,
+language,mdf,Moksha,http://id.loc.gov/vocabulary/languages/mdf,
+language,mdr,Mandar,http://id.loc.gov/vocabulary/languages/mdr,
+language,men,Mende,http://id.loc.gov/vocabulary/languages/men,
+language,mga,"Irish, Middle (ca. 1100-1550)",http://id.loc.gov/vocabulary/languages/mga,
+language,mic,Micmac,http://id.loc.gov/vocabulary/languages/mic,
+language,min,Minangkabau,http://id.loc.gov/vocabulary/languages/min,
+language,mis,Miscellaneous languages,http://id.loc.gov/vocabulary/languages/mis,
+language,mkh,Mon-Khmer (Other),http://id.loc.gov/vocabulary/languages/mkh,
+language,mlg,Malagasy,http://id.loc.gov/vocabulary/languages/mlg,
+language,mlt,Maltese,http://id.loc.gov/vocabulary/languages/mlt,
+language,mnc,Manchu,http://id.loc.gov/vocabulary/languages/mnc,
+language,mni,Manipuri,http://id.loc.gov/vocabulary/languages/mni,
+language,mno,Manobo languages,http://id.loc.gov/vocabulary/languages/mno,
+language,moh,Mohawk,http://id.loc.gov/vocabulary/languages/moh,
+language,mon,Mongolian,http://id.loc.gov/vocabulary/languages/mon,
+language,mos,Mooré,http://id.loc.gov/vocabulary/languages/mos,
+language,mul,Multiple languages,http://id.loc.gov/vocabulary/languages/mul,
+language,mun,Munda (Other),http://id.loc.gov/vocabulary/languages/mun,
+language,mus,Creek,http://id.loc.gov/vocabulary/languages/mus,
+language,mwl,Mirandese,http://id.loc.gov/vocabulary/languages/mwl,
+language,mwr,Marwari,http://id.loc.gov/vocabulary/languages/mwr,
+language,myn,Mayan languages,http://id.loc.gov/vocabulary/languages/myn,
+language,myv,Erzya,http://id.loc.gov/vocabulary/languages/myv,
+language,nah,Nahuatl,http://id.loc.gov/vocabulary/languages/nah,
+language,nai,North American Indian (Other),http://id.loc.gov/vocabulary/languages/nai,
+language,nap,Neapolitan Italian,http://id.loc.gov/vocabulary/languages/nap,
+language,nau,Nauru,http://id.loc.gov/vocabulary/languages/nau,
+language,nav,Navajo,http://id.loc.gov/vocabulary/languages/nav,
+language,nbl,Ndebele (South Africa),http://id.loc.gov/vocabulary/languages/nbl,
+language,nde,Ndebele (Zimbabwe),http://id.loc.gov/vocabulary/languages/nde,
+language,ndo,Ndonga,http://id.loc.gov/vocabulary/languages/ndo,
+language,nds,Low German,http://id.loc.gov/vocabulary/languages/nds,
+language,nep,Nepali,http://id.loc.gov/vocabulary/languages/nep,
+language,new,Newari,http://id.loc.gov/vocabulary/languages/new,
+language,nia,Nias,http://id.loc.gov/vocabulary/languages/nia,
+language,nic,Niger-Kordofanian (Other),http://id.loc.gov/vocabulary/languages/nic,
+language,niu,Niuean,http://id.loc.gov/vocabulary/languages/niu,
+language,nno,Norwegian (Nynorsk),http://id.loc.gov/vocabulary/languages/nno,
+language,nob,Norwegian (Bokmål),http://id.loc.gov/vocabulary/languages/nob,
+language,nog,Nogai,http://id.loc.gov/vocabulary/languages/nog,
+language,non,Old Norse,http://id.loc.gov/vocabulary/languages/non,
+language,nor,Norwegian,http://id.loc.gov/vocabulary/languages/nor,
+language,nqo,N'Ko,http://id.loc.gov/vocabulary/languages/nqo,
+language,nso,Northern Sotho,http://id.loc.gov/vocabulary/languages/nso,
+language,nub,Nubian languages,http://id.loc.gov/vocabulary/languages/nub,
+language,nwc,"Newari, Old",http://id.loc.gov/vocabulary/languages/nwc,
+language,nya,Nyanja,http://id.loc.gov/vocabulary/languages/nya,
+language,nym,Nyamwezi,http://id.loc.gov/vocabulary/languages/nym,
+language,nyn,Nyankole,http://id.loc.gov/vocabulary/languages/nyn,
+language,nyo,Nyoro,http://id.loc.gov/vocabulary/languages/nyo,
+language,nzi,Nzima,http://id.loc.gov/vocabulary/languages/nzi,
+language,oci,Occitan (post-1500),http://id.loc.gov/vocabulary/languages/oci,
+language,oji,Ojibwa,http://id.loc.gov/vocabulary/languages/oji,
+language,ori,Oriya,http://id.loc.gov/vocabulary/languages/ori,
+language,orm,Oromo,http://id.loc.gov/vocabulary/languages/orm,
+language,osa,Osage,http://id.loc.gov/vocabulary/languages/osa,
+language,oss,Ossetic,http://id.loc.gov/vocabulary/languages/oss,
+language,ota,"Turkish, Ottoman",http://id.loc.gov/vocabulary/languages/ota,
+language,oto,Otomian languages,http://id.loc.gov/vocabulary/languages/oto,
+language,paa,Papuan (Other),http://id.loc.gov/vocabulary/languages/paa,
+language,pag,Pangasinan,http://id.loc.gov/vocabulary/languages/pag,
+language,pal,Pahlavi,http://id.loc.gov/vocabulary/languages/pal,
+language,pam,Pampanga,http://id.loc.gov/vocabulary/languages/pam,
+language,pan,Panjabi,http://id.loc.gov/vocabulary/languages/pan,
+language,pap,Papiamento,http://id.loc.gov/vocabulary/languages/pap,
+language,pau,Palauan,http://id.loc.gov/vocabulary/languages/pau,
+language,peo,Old Persian (ca. 600-400 B.C.),http://id.loc.gov/vocabulary/languages/peo,
+language,per,Persian,http://id.loc.gov/vocabulary/languages/per,
+language,phi,Philippine (Other),http://id.loc.gov/vocabulary/languages/phi,
+language,phn,Phoenician,http://id.loc.gov/vocabulary/languages/phn,
+language,pli,Pali,http://id.loc.gov/vocabulary/languages/pli,
+language,pol,Polish,http://id.loc.gov/vocabulary/languages/pol,
+language,pon,Pohnpeian,http://id.loc.gov/vocabulary/languages/pon,
+language,por,Portuguese,http://id.loc.gov/vocabulary/languages/por,
+language,pra,Prakrit languages,http://id.loc.gov/vocabulary/languages/pra,
+language,pro,Provençal (to 1500),http://id.loc.gov/vocabulary/languages/pro,
+language,pus,Pushto,http://id.loc.gov/vocabulary/languages/pus,
+language,que,Quechua,http://id.loc.gov/vocabulary/languages/que,
+language,raj,Rajasthani,http://id.loc.gov/vocabulary/languages/raj,
+language,rap,Rapanui,http://id.loc.gov/vocabulary/languages/rap,
+language,rar,Rarotongan,http://id.loc.gov/vocabulary/languages/rar,
+language,roa,Romance (Other),http://id.loc.gov/vocabulary/languages/roa,
+language,roh,Raeto-Romance,http://id.loc.gov/vocabulary/languages/roh,
+language,rom,Romani,http://id.loc.gov/vocabulary/languages/rom,
+language,rum,Romanian,http://id.loc.gov/vocabulary/languages/rum,
+language,run,Rundi,http://id.loc.gov/vocabulary/languages/run,
+language,rup,Aromanian,http://id.loc.gov/vocabulary/languages/rup,
+language,rus,Russian,http://id.loc.gov/vocabulary/languages/rus,
+language,sad,Sandawe,http://id.loc.gov/vocabulary/languages/sad,
+language,sag,Sango (Ubangi Creole),http://id.loc.gov/vocabulary/languages/sag,
+language,sah,Yakut,http://id.loc.gov/vocabulary/languages/sah,
+language,sai,South American Indian (Other),http://id.loc.gov/vocabulary/languages/sai,
+language,sal,Salishan languages,http://id.loc.gov/vocabulary/languages/sal,
+language,sam,Samaritan Aramaic,http://id.loc.gov/vocabulary/languages/sam,
+language,san,Sanskrit,http://id.loc.gov/vocabulary/languages/san,
+language,sas,Sasak,http://id.loc.gov/vocabulary/languages/sas,
+language,sat,Santali,http://id.loc.gov/vocabulary/languages/sat,
+language,scn,Sicilian Italian,http://id.loc.gov/vocabulary/languages/scn,
+language,sco,Scots,http://id.loc.gov/vocabulary/languages/sco,
+language,sel,Selkup,http://id.loc.gov/vocabulary/languages/sel,
+language,sem,Semitic (Other),http://id.loc.gov/vocabulary/languages/sem,
+language,sga,"Irish, Old (to 1100)",http://id.loc.gov/vocabulary/languages/sga,
+language,sgn,Sign languages,http://id.loc.gov/vocabulary/languages/sgn,
+language,shn,Shan,http://id.loc.gov/vocabulary/languages/shn,
+language,sid,Sidamo,http://id.loc.gov/vocabulary/languages/sid,
+language,sin,Sinhalese,http://id.loc.gov/vocabulary/languages/sin,
+language,sio,Siouan (Other),http://id.loc.gov/vocabulary/languages/sio,
+language,sit,Sino-Tibetan (Other),http://id.loc.gov/vocabulary/languages/sit,
+language,sla,Slavic (Other),http://id.loc.gov/vocabulary/languages/sla,
+language,slo,Slovak,http://id.loc.gov/vocabulary/languages/slo,
+language,slv,Slovenian,http://id.loc.gov/vocabulary/languages/slv,
+language,sma,Southern Sami,http://id.loc.gov/vocabulary/languages/sma,
+language,sme,Northern Sami,http://id.loc.gov/vocabulary/languages/sme,
+language,smi,Sami,http://id.loc.gov/vocabulary/languages/smi,
+language,smj,Lule Sami,http://id.loc.gov/vocabulary/languages/smj,
+language,smn,Inari Sami,http://id.loc.gov/vocabulary/languages/smn,
+language,smo,Samoan,http://id.loc.gov/vocabulary/languages/smo,
+language,sms,Skolt Sami,http://id.loc.gov/vocabulary/languages/sms,
+language,sna,Shona,http://id.loc.gov/vocabulary/languages/sna,
+language,snd,Sindhi,http://id.loc.gov/vocabulary/languages/snd,
+language,snk,Soninke,http://id.loc.gov/vocabulary/languages/snk,
+language,sog,Sogdian,http://id.loc.gov/vocabulary/languages/sog,
+language,som,Somali,http://id.loc.gov/vocabulary/languages/som,
+language,son,Songhai,http://id.loc.gov/vocabulary/languages/son,
+language,sot,Sotho,http://id.loc.gov/vocabulary/languages/sot,
+language,spa,Spanish,http://id.loc.gov/vocabulary/languages/spa,
+language,srd,Sardinian,http://id.loc.gov/vocabulary/languages/srd,
+language,srn,Sranan,http://id.loc.gov/vocabulary/languages/srn,
+language,srp,Serbian,http://id.loc.gov/vocabulary/languages/srp,
+language,srr,Serer,http://id.loc.gov/vocabulary/languages/srr,
+language,ssa,Nilo-Saharan (Other),http://id.loc.gov/vocabulary/languages/ssa,
+language,ssw,Swazi,http://id.loc.gov/vocabulary/languages/ssw,
+language,suk,Sukuma,http://id.loc.gov/vocabulary/languages/suk,
+language,sun,Sundanese,http://id.loc.gov/vocabulary/languages/sun,
+language,sus,Susu,http://id.loc.gov/vocabulary/languages/sus,
+language,sux,Sumerian,http://id.loc.gov/vocabulary/languages/sux,
+language,swa,Swahili,http://id.loc.gov/vocabulary/languages/swa,
+language,swe,Swedish,http://id.loc.gov/vocabulary/languages/swe,
+language,syc,Syriac,http://id.loc.gov/vocabulary/languages/syc,
+language,syr,"Syriac, Modern",http://id.loc.gov/vocabulary/languages/syr,
+language,tah,Tahitian,http://id.loc.gov/vocabulary/languages/tah,
+language,tai,Tai (Other),http://id.loc.gov/vocabulary/languages/tai,
+language,tam,Tamil,http://id.loc.gov/vocabulary/languages/tam,
+language,tat,Tatar,http://id.loc.gov/vocabulary/languages/tat,
+language,tel,Telugu,http://id.loc.gov/vocabulary/languages/tel,
+language,tem,Temne,http://id.loc.gov/vocabulary/languages/tem,
+language,ter,Terena,http://id.loc.gov/vocabulary/languages/ter,
+language,tet,Tetum,http://id.loc.gov/vocabulary/languages/tet,
+language,tgk,Tajik,http://id.loc.gov/vocabulary/languages/tgk,
+language,tgl,Tagalog,http://id.loc.gov/vocabulary/languages/tgl,
+language,tha,Thai,http://id.loc.gov/vocabulary/languages/tha,
+language,tib,Tibetan,http://id.loc.gov/vocabulary/languages/tib,
+language,tig,Tigré,http://id.loc.gov/vocabulary/languages/tig,
+language,tir,Tigrinya,http://id.loc.gov/vocabulary/languages/tir,
+language,tiv,Tiv,http://id.loc.gov/vocabulary/languages/tiv,
+language,tkl,Tokelauan,http://id.loc.gov/vocabulary/languages/tkl,
+language,tlh,Klingon (Artificial language),http://id.loc.gov/vocabulary/languages/tlh,
+language,tli,Tlingit,http://id.loc.gov/vocabulary/languages/tli,
+language,tmh,Tamashek,http://id.loc.gov/vocabulary/languages/tmh,
+language,tog,Tonga (Nyasa),http://id.loc.gov/vocabulary/languages/tog,
+language,ton,Tongan,http://id.loc.gov/vocabulary/languages/ton,
+language,tpi,Tok Pisin,http://id.loc.gov/vocabulary/languages/tpi,
+language,tsi,Tsimshian,http://id.loc.gov/vocabulary/languages/tsi,
+language,tsn,Tswana,http://id.loc.gov/vocabulary/languages/tsn,
+language,tso,Tsonga,http://id.loc.gov/vocabulary/languages/tso,
+language,tuk,Turkmen,http://id.loc.gov/vocabulary/languages/tuk,
+language,tum,Tumbuka,http://id.loc.gov/vocabulary/languages/tum,
+language,tup,Tupi languages,http://id.loc.gov/vocabulary/languages/tup,
+language,tur,Turkish,http://id.loc.gov/vocabulary/languages/tur,
+language,tut,Altaic (Other),http://id.loc.gov/vocabulary/languages/tut,
+language,tvl,Tuvaluan,http://id.loc.gov/vocabulary/languages/tvl,
+language,twi,Twi,http://id.loc.gov/vocabulary/languages/twi,
+language,tyv,Tuvinian,http://id.loc.gov/vocabulary/languages/tyv,
+language,udm,Udmurt,http://id.loc.gov/vocabulary/languages/udm,
+language,uga,Ugaritic,http://id.loc.gov/vocabulary/languages/uga,
+language,uig,Uighur,http://id.loc.gov/vocabulary/languages/uig,
+language,ukr,Ukrainian,http://id.loc.gov/vocabulary/languages/ukr,
+language,umb,Umbundu,http://id.loc.gov/vocabulary/languages/umb,
+language,und,Undetermined,http://id.loc.gov/vocabulary/languages/und,
+language,urd,Urdu,http://id.loc.gov/vocabulary/languages/urd,
+language,uzb,Uzbek,http://id.loc.gov/vocabulary/languages/uzb,
+language,vai,Vai,http://id.loc.gov/vocabulary/languages/vai,
+language,ven,Venda,http://id.loc.gov/vocabulary/languages/ven,
+language,vie,Vietnamese,http://id.loc.gov/vocabulary/languages/vie,
+language,vol,Volapük,http://id.loc.gov/vocabulary/languages/vol,
+language,vot,Votic,http://id.loc.gov/vocabulary/languages/vot,
+language,wak,Wakashan languages,http://id.loc.gov/vocabulary/languages/wak,
+language,wal,Wolayta,http://id.loc.gov/vocabulary/languages/wal,
+language,war,Waray,http://id.loc.gov/vocabulary/languages/war,
+language,was,Washoe,http://id.loc.gov/vocabulary/languages/was,
+language,wel,Welsh,http://id.loc.gov/vocabulary/languages/wel,
+language,wen,Sorbian (Other),http://id.loc.gov/vocabulary/languages/wen,
+language,wln,Walloon,http://id.loc.gov/vocabulary/languages/wln,
+language,wol,Wolof,http://id.loc.gov/vocabulary/languages/wol,
+language,xal,Oirat,http://id.loc.gov/vocabulary/languages/xal,
+language,xho,Xhosa,http://id.loc.gov/vocabulary/languages/xho,
+language,yao,Yao (Africa),http://id.loc.gov/vocabulary/languages/yao,
+language,yap,Yapese,http://id.loc.gov/vocabulary/languages/yap,
+language,yid,Yiddish,http://id.loc.gov/vocabulary/languages/yid,
+language,yor,Yoruba,http://id.loc.gov/vocabulary/languages/yor,
+language,ypk,Yupik languages,http://id.loc.gov/vocabulary/languages/ypk,
+language,zap,Zapotec,http://id.loc.gov/vocabulary/languages/zap,
+language,zbl,Blissymbolics,http://id.loc.gov/vocabulary/languages/zbl,
+language,zen,Zenaga,http://id.loc.gov/vocabulary/languages/zen,
+language,zha,Zhuang,http://id.loc.gov/vocabulary/languages/zha,
+language,znd,Zande languages,http://id.loc.gov/vocabulary/languages/znd,
+language,zul,Zulu,http://id.loc.gov/vocabulary/languages/zul,
+language,zun,Zuni,http://id.loc.gov/vocabulary/languages/zun,
+language,zxx,No linguistic content,http://id.loc.gov/vocabulary/languages/zxx,
+language,zza,Zaza,http://id.loc.gov/vocabulary/languages/zza,

--- a/web/themes/custom/asulib_barrio/asulib_barrio.theme
+++ b/web/themes/custom/asulib_barrio/asulib_barrio.theme
@@ -96,6 +96,13 @@ function asulib_barrio_preprocess_node(&$variables) {
       $domain = $url_parts[2];
       $variables['oai_base_url'] = $site_url . 'oai/request?verb=GetRecord&metadataPrefix=oai_dc&identifier=oai:' . $domain . ':node-';
     }
+    $node_language = $node->get('field_language')->entity;
+    $variables['hreflang_attr'] = '';
+    if ($node_language) {
+      if ($node_language->hasField('field_langcode_2digits') && $node_language->get('field_langcode_2digits')->value) {
+        $variables['hreflang_attr'] = $node_language->get('field_langcode_2digits')->value;
+      }
+    }
     if ($variables['view_mode'] == 'complex_object_child_box') {
       // since we are pulling the $node var from the route, we're actually already on the parent obj page
       $parent_obj = \Drupal::request()->attributes->get('node');
@@ -248,7 +255,7 @@ function asulib_barrio_preprocess_page(&$variables) {
  * Implements hook_preprocess_image()
  */
 function asulib_barrio_preprocess_image(&$variables) {
-  if ($variables['style_name'] == 'card_image') {
+  if ($variables['style_name'] == 'card_image' || $variables['style_name'] == 'horizontal_card_image') {
     $variables['attributes']['class'][] = 'card-img-top';
   }
 }

--- a/web/themes/custom/asulib_barrio/asulib_barrio.theme
+++ b/web/themes/custom/asulib_barrio/asulib_barrio.theme
@@ -255,7 +255,7 @@ function asulib_barrio_preprocess_page(&$variables) {
  * Implements hook_preprocess_image()
  */
 function asulib_barrio_preprocess_image(&$variables) {
-  if ($variables['style_name'] == 'card_image' || $variables['style_name'] == 'horizontal_card_image') {
+  if ($variables['style_name'] == 'card_image') {
     $variables['attributes']['class'][] = 'card-img-top';
   }
 }

--- a/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--asu-document.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--asu-document.html.twig
@@ -99,7 +99,7 @@
     <div class="content-section row">
       <div class="col-md-5 file-container">
         {% if of_access %}
-          <a href="{{ url }}/view" class="image-link">{{ content.display_media_thumbnail }}</a>
+          <a href="{{ url }}/view" class="image-link"{% if hreflang_attr %} hreflang="{{ hreflang_attr }}"{% endif %}>{{ content.display_media_thumbnail }}</a>
         {% else %}
           {{ content.display_media_thumbnail }}
         {% endif %}

--- a/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--asu-image.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--asu-image.html.twig
@@ -99,7 +99,7 @@
     <div class="content-section row">
       <div class="col-md-5 file-container">
         {% if of_access %}
-          <a href="{{ url }}/view" class="image-link">{{ content.display_media_thumbnail }}</a>
+          <a href="{{ url }}/view" class="image-link"{% if hreflang_attr %} hreflang="{{ hreflang_attr }}"{% endif %}>{{ content.display_media_thumbnail }}</a>
         {% else %}
           {{ content.display_media_thumbnail }}
         {% endif %}

--- a/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--complex-object-child-box.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--complex-object-child-box.html.twig
@@ -113,7 +113,7 @@
             {{ drupal_block('downloads_block', {'child_node_id': node.id, 'origfile': original_file, 'servicefile': service_file}) }}
           </div>
           {% if mod == 'Image' or mod == 'Digital Document' %}
-            <a href="/items/{{ node.id }}/view">Preview</a><br/>
+            <a href="/items/{{ node.id }}/view"{% if hreflang_attr %} hreflang="{{ hreflang_attr }}"{% endif %}>Preview</a><br/>
           {% elseif (mod == 'Audio' or mod == 'Video') and (of_access or sf_access) %}
             <a data-toggle="collapse" href="#player{{ node.id }}" role="button" aria-expanded="false" aria-controls="player{{ node.id }}"><i class="far fa-play-circle"></i> Play</a><br/>
             <div id="player{{ node.id }}" class="collapse">


### PR DESCRIPTION
This enhancement is a stand-alone set of changes that will allow for the language codes to be added to the ./view and download links for media that are attached to any node which has a language code that is included in the set of 2 digit language codes (that also map to our existing 3 digit language codes that are part of our languages taxonomy vocabulary).

After pulling down this branch, the updated taxonomy vocabulary will need to be updated. This is done by 
```
cd /var/www/html/drupal
rm -f config/1time/*
cp web/modules/custom/asu_taxonomies/config/install/migrate_plus.migration.languages.yml config/1time/.
cp config/sync/core.entity_view_display.taxonomy_term.language.default.yml config/1time/.
cp config/sync/core.entity_form_display.taxonomy_term.language.default.yml config/1time/.
cp config/sync/field.field.taxonomy_term.language.field_langcode_2digits.yml config/1time/.
cp config/sync/field.storage.taxonomy_term.field_langcode_2digits.yml config/1time/.
cp web/modules/custom/asu_taxonomies/config/install/migrate_plus.migration.languages.yml config/1time/.
drush config:import --partial --source /var/www/html/drupal/config/1time
drush cr
drush migrate:import languages --update
```

If that all works (my fingers-crossed), then the system should now be configured to display the 2 digit language codes for any asu_repository_item's download button (links) as well as the ./view link from their thumbnails -- provided this node has one of the languages selected that actually has a langcode mapping to one of our existing language terms. Refer either to the `web/modules/custom/asu_taxonomies/migrate/languages.csv or the ISO 639-1 specification details (https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).

Some nodes' language may need to be edited in order to confirm that these links are updated with the html attribute on those links like `hreflang="fr"`.