### PR TITLE
Seo friendlyurls

### DIFF
--- a/config/sync/pathauto.pattern.collections.yml
+++ b/config/sync/pathauto.pattern.collections.yml
@@ -3,19 +3,19 @@ status: true
 dependencies:
   module:
     - node
-id: items_nids
-label: 'Items nids'
+id: collections
+label: Collections
 type: 'canonical_entities:node'
-pattern: '/items/[node:nid]'
+pattern: '/collections/[node:title]'
 selection_criteria:
-  236fa3de-aeac-411c-bfb2-29428c25e37b:
+  83b325ab-2006-4033-85ed-c22cf5274a3f:
     id: node_type
     bundles:
-      asu_repository_item: asu_repository_item
+      collection: collection
     negate: false
     context_mapping:
       node: node
-    uuid: 236fa3de-aeac-411c-bfb2-29428c25e37b
+    uuid: 83b325ab-2006-4033-85ed-c22cf5274a3f
 selection_logic: and
-weight: -5
+weight: -10
 relationships: {  }

--- a/config/sync/pathauto.pattern.collections_nids.yml
+++ b/config/sync/pathauto.pattern.collections_nids.yml
@@ -4,18 +4,18 @@ dependencies:
   module:
     - node
 id: collections_nids
-label: 'Collections Nids'
+label: 'Collections nids'
 type: 'canonical_entities:node'
 pattern: '/collections/[node:nid]'
 selection_criteria:
-  524fae2e-f383-4b3a-8ad3-cacec0680f0d:
+  5031583c-30a1-4609-a817-180bb301e2f3:
     id: node_type
     bundles:
       collection: collection
     negate: false
     context_mapping:
       node: node
-    uuid: 524fae2e-f383-4b3a-8ad3-cacec0680f0d
+    uuid: 5031583c-30a1-4609-a817-180bb301e2f3
 selection_logic: and
 weight: -5
 relationships: {  }

--- a/config/sync/pathauto.pattern.corporate_bodies.yml
+++ b/config/sync/pathauto.pattern.corporate_bodies.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - ctools
+    - taxonomy
+id: corporate_bodies
+label: 'Corporate bodies'
+type: 'canonical_entities:taxonomy_term'
+pattern: '/corporate bodies/[term:name]'
+selection_criteria:
+  d3564123-ce9a-4ce8-b432-2b1f5966091a:
+    id: 'entity_bundle:taxonomy_term'
+    bundles:
+      corporate_body: corporate_body
+    negate: false
+    context_mapping:
+      taxonomy_term: taxonomy_term
+    uuid: d3564123-ce9a-4ce8-b432-2b1f5966091a
+selection_logic: and
+weight: -5
+relationships: {  }

--- a/config/sync/pathauto.pattern.corporate_bodies.yml
+++ b/config/sync/pathauto.pattern.corporate_bodies.yml
@@ -7,16 +7,16 @@ dependencies:
 id: corporate_bodies
 label: 'Corporate bodies'
 type: 'canonical_entities:taxonomy_term'
-pattern: '/corporate bodies/[term:name]'
+pattern: '/corporate_bodies/[term:name]'
 selection_criteria:
-  d3564123-ce9a-4ce8-b432-2b1f5966091a:
+  18fcc40f-15d5-4bc5-9319-2e92bce99aa1:
     id: 'entity_bundle:taxonomy_term'
     bundles:
       corporate_body: corporate_body
     negate: false
     context_mapping:
       taxonomy_term: taxonomy_term
-    uuid: d3564123-ce9a-4ce8-b432-2b1f5966091a
+    uuid: 18fcc40f-15d5-4bc5-9319-2e92bce99aa1
 selection_logic: and
 weight: -5
 relationships: {  }

--- a/config/sync/pathauto.pattern.events_conference_.yml
+++ b/config/sync/pathauto.pattern.events_conference_.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - ctools
+    - taxonomy
+id: events_conference_
+label: 'Events (Conference)'
+type: 'canonical_entities:taxonomy_term'
+pattern: '/events/[term:name]'
+selection_criteria:
+  f494399e-21f0-4c3c-9a84-bae2a88aaa11:
+    id: 'entity_bundle:taxonomy_term'
+    bundles:
+      conference: conference
+    negate: false
+    context_mapping:
+      taxonomy_term: taxonomy_term
+    uuid: f494399e-21f0-4c3c-9a84-bae2a88aaa11
+selection_logic: and
+weight: -5
+relationships: {  }

--- a/config/sync/pathauto.pattern.items.yml
+++ b/config/sync/pathauto.pattern.items.yml
@@ -3,19 +3,19 @@ status: true
 dependencies:
   module:
     - node
-id: items_nids
-label: 'Items nids'
+id: items
+label: Items
 type: 'canonical_entities:node'
-pattern: '/items/[node:nid]'
+pattern: '/items/[node:title]'
 selection_criteria:
-  236fa3de-aeac-411c-bfb2-29428c25e37b:
+  9f07cfe3-1f83-45f4-bb7a-7ceede98cd66:
     id: node_type
     bundles:
       asu_repository_item: asu_repository_item
     negate: false
     context_mapping:
       node: node
-    uuid: 236fa3de-aeac-411c-bfb2-29428c25e37b
+    uuid: 9f07cfe3-1f83-45f4-bb7a-7ceede98cd66
 selection_logic: and
-weight: -5
+weight: -10
 relationships: {  }

--- a/config/sync/pathauto.pattern.persons.yml
+++ b/config/sync/pathauto.pattern.persons.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - ctools
+    - taxonomy
+id: persons
+label: 'Persons (Family, Person)'
+type: 'canonical_entities:taxonomy_term'
+pattern: '/people/[term:name]'
+selection_criteria:
+  cf5ca683-df08-472b-a038-dfe213fc51da:
+    id: 'entity_bundle:taxonomy_term'
+    bundles:
+      family: family
+      person: person
+    negate: false
+    context_mapping:
+      taxonomy_term: taxonomy_term
+    uuid: cf5ca683-df08-472b-a038-dfe213fc51da
+selection_logic: and
+weight: -5
+relationships: {  }

--- a/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--asu-audio.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--asu-audio.html.twig
@@ -170,7 +170,7 @@
       <div>
         <p>
           <strong>
-            <a class="icon-link" href="{{ url }}/metadata"><i class="fa fa-lg fa-list-ul"></i><span>{{ 'View full metadata'|t }}</span></a>
+            <a class="icon-link" href="/items/{{ node.id }}/metadata"><i class="fa fa-lg fa-list-ul"></i><span>{{ 'View full metadata'|t }}</span></a>
           </strong>
         </p>
       </div>

--- a/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--asu-complex-object.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--asu-complex-object.html.twig
@@ -99,7 +99,7 @@
     <div class="content-section row">
       {% if drupal_view('display_media', 'thumbnail', node.id)|render|striptags|trim|length > 0 %}
         <div class="col-md-5 file-container">
-          <a href="{{ url }}/members" class="image-link">{{ drupal_view('display_media', 'thumbnail', node.id) }}</a>
+          <a href="/items/{{ node.id }}/members" class="image-link">{{ drupal_view('display_media', 'thumbnail', node.id) }}</a>
         </div>
         {% set desc_width = "col-md-7" %}
       {% else %}
@@ -123,7 +123,7 @@
       </div>
       <br class="clearfloat">
       <div><p><strong>
-        <a href="{{ url }}/members" class="btn btn-primary">View all associated media</a></strong></p></div><br/>
+        <a href="/items/{{ node.id }}/members" class="btn btn-primary">View all associated media</a></strong></p></div><br/>
     </div>
     <div id="details" class="content-section details">
       <h2>{{ 'Details'|t }}</h2>
@@ -170,7 +170,7 @@
       <div>
         <p>
           <strong>
-            <a class="icon-link" href="{{ url }}/metadata">
+            <a class="icon-link" href="/items/{{ node.id }}/metadata">
               <i class="fa fa-lg fa-list-ul"></i>
               <span>{{ 'View full metadata'|t }}</span>
             </a>

--- a/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--asu-document.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--asu-document.html.twig
@@ -99,7 +99,7 @@
     <div class="content-section row">
       <div class="col-md-5 file-container">
         {% if of_access %}
-          <a href="{{ url }}/view" class="image-link">{{ content.display_media_thumbnail }}</a>
+          <a href="/items/{{ node.id }}/view" class="image-link">{{ content.display_media_thumbnail }}</a>
         {% else %}
           {{ content.display_media_thumbnail }}
         {% endif %}
@@ -166,7 +166,7 @@
       <div>
         <p>
           <strong>
-            <a class="icon-link" href="{{ url }}/metadata"><i class="fa fa-lg fa-list-ul"></i><span>{{ 'View full metadata'|t }}</span></a>
+            <a class="icon-link" href="/items/{{ node.id }}/metadata"><i class="fa fa-lg fa-list-ul"></i><span>{{ 'View full metadata'|t }}</span></a>
           </strong>
         </p>
       </div>

--- a/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--asu-image.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--asu-image.html.twig
@@ -99,7 +99,7 @@
     <div class="content-section row">
       <div class="col-md-5 file-container">
         {% if of_access %}
-          <a href="{{ url }}/view" class="image-link">{{ content.display_media_thumbnail }}</a>
+          <a href="/items/{{ node.id }}/view" class="image-link">{{ content.display_media_thumbnail }}</a>
         {% else %}
           {{ content.display_media_thumbnail }}
         {% endif %}
@@ -166,7 +166,7 @@
       <div>
         <p>
           <strong>
-            <a class="icon-link" href="{{ url }}/metadata"><i class="fa fa-lg fa-list-ul"></i><span>{{ 'View full metadata'|t }}</span></a>
+            <a class="icon-link" href="/items/{{ node.id }}/metadata"><i class="fa fa-lg fa-list-ul"></i><span>{{ 'View full metadata'|t }}</span></a>
           </strong>
         </p>
       </div>

--- a/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--asu-video.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--asu-video.html.twig
@@ -172,7 +172,7 @@
       <div>
         <p>
           <strong>
-            <a class="icon-link" href="{{ url }}/metadata"><i class="fa fa-lg fa-list-ul"></i><span>{{ 'View full metadata'|t }}</span></a>
+            <a class="icon-link" href="/items/{{ node.id }}/metadata"><i class="fa fa-lg fa-list-ul"></i><span>{{ 'View full metadata'|t }}</span></a>
           </strong>
         </p>
       </div>

--- a/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--full.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--full.html.twig
@@ -157,7 +157,7 @@
       <div>
         <p>
           <strong>
-            <a class="icon-link" href="{{ url }}/metadata"><i class="fa fa-lg fa-list-ul"></i><span>{{ 'View full metadata'|t }}</span></a>
+            <a class="icon-link" href="/items/{{ node.id }}/metadata"><i class="fa fa-lg fa-list-ul"></i><span>{{ 'View full metadata'|t }}</span></a>
           </strong>
         </p>
       </div>


### PR DESCRIPTION
This feature branch includes minor adjustments to links in several of the templates/content twig files (so that they can still be routed to the handler) as well as an update to the pathauto configurations for items, collections, and several taxonomies (Corporate bodies, Events (Conference), and Persons (Family, Person)).

Import the following configuration files and clear the cache. Additionally, the sitemap file can be purged at this time - to confirm that the new sitemap's urls would be the friendly urls.

Import the config/sync files 
```
pathauto.pattern.collections.yml
pathauto.pattern.collections_nids.yml
pathauto.pattern.corporate_bodies.yml
pathauto.pattern.events_conference_.yml
pathauto.pattern.items.yml, 
pathauto.pattern.items_nids.yml
pathauto.pattern.persons.yml 
```

To purge the previous sitemap file, `drush sql-query "truncate table simple_sitemap;"`

The new pathauto patterns use the tokens:

- Collections | /collections/[node:title]
- Items | /items/[node:title]
- Corporate bodies | /corporate bodies/[term:name]
- Events (Conference) | /events/[term:name]
- Persons (Family, Person) | /people/[term:name]

While the previous patterns should stay intact _(while the system prefers the above patterns, it will still handle these routes)_:

- Collections nids | /collections/[node:nid]
- Items nids | /items/[node:nid]

While the agent links are all set to a pre-canned search GET url for that agent, these entities do still have core Drupal routes set up for them such as http://localhost:8000/people/pannabecker-virginia - which were previously set up with default route that looks like this: http://localhost:8000/taxonomy/term/54. We may want to add these core paths to the sitemap.

Look for ./view, ./metadata links on image, digital document item pages. Look for ./members on complex object parent item pages. Look for ./metadata on all other item pages. Additionally, test that the routes for a collection and an item still work when using the [node:nid] route.