### PR TITLE
adjusted URL for Download CSV link for #452

### DIFF
--- a/web/modules/custom/asu_search/asu_search.module
+++ b/web/modules/custom/asu_search/asu_search.module
@@ -169,7 +169,13 @@ function asu_search_views_pre_render(ViewExecutable $view) {
       $query_parts = \Drupal::request()->query->all();
       $query_string_parts = [];
       foreach ($query_parts as $query_key => $query_value) {
-        $query_string_parts[] = $query_key . '=' . $query_value;
+        if (is_array($query_value)) {
+          foreach ($query_value as $key_key => $query_value_value) {
+            $query_string_parts[] = $query_key . '[' . $key_key . ']=' . $query_value_value;
+          }
+        } else {
+          $query_string_parts[] = $query_key . '=' . $query_value;
+        }
       }
       $query_string = implode("&", $query_string_parts);
       $view->header['area_1']->options['content']['value'] .= ' | ' . "<a href='" .


### PR DESCRIPTION
This tiny change is a bugfix to the URL that is generated to Download CSV for any search page (appears for Metadata manager and Administrator users).

Simply pull down this code and clear the cache and navigate to a faceted search results screen such as https://localhost:8000/search?search_api_fulltext=&sort_by=search_api_relevance&items_per_page=10&f%5B0%5D=member_of%3APardon%2C%20Kevin. NOTE: this functionality is not available for a collection search results page.