### PR TITLE
Hover titles 500

### DIFF
--- a/web/modules/custom/asu_item_extras/src/Plugin/Block/DownloadsBlock.php
+++ b/web/modules/custom/asu_item_extras/src/Plugin/Block/DownloadsBlock.php
@@ -199,7 +199,7 @@ class DownloadsBlock extends BlockBase implements ContainerFactoryPluginInterfac
       if (!empty($source_field)) {
         $pmf_file = $masterfile->get($source_field)->referencedEntities()[0];
         $pmf_uri = $islandora_utils->getDownloadUrl($pmf_file);
-        $pmf_link = Link::fromTextAndUrl($this->t('Master'), Url::fromUri($pmf_uri, ['attributes' => ['class' => ['dropdown-item'], 'title' => $this->t('Download original')]]));
+        $pmf_link = Link::fromTextAndUrl($this->t('Master'), Url::fromUri($pmf_uri, ['attributes' => ['class' => ['dropdown-item'], 'title' => $this->t('Download master')]]));
         // $download_info .= $masterfile->get('field_mime_type')->value;
       }
     }

--- a/web/modules/custom/asu_item_extras/src/Plugin/Block/DownloadsBlock.php
+++ b/web/modules/custom/asu_item_extras/src/Plugin/Block/DownloadsBlock.php
@@ -176,7 +176,7 @@ class DownloadsBlock extends BlockBase implements ContainerFactoryPluginInterfac
         $of_file = ($origfile->hasField($source_field) && (is_object($origfile->get($source_field)) && $origfile->get($source_field)->referencedEntities() != NULL) ? $origfile->get($source_field)->referencedEntities()[0] : FALSE);
         if ($of_file) {
           $of_uri = $islandora_utils->getDownloadUrl($of_file);
-          $of_link = Link::fromTextAndUrl($this->t('Original'), Url::fromUri($of_uri, ['attributes' => ['class' => ['dropdown-item'], 'download' => TRUE]]));
+          $of_link = Link::fromTextAndUrl($this->t('Original'), Url::fromUri($of_uri, ['attributes' => ['class' => ['dropdown-item'], 'download' => TRUE, 'title' => $this->t('Download original')]]));
           $file_size = $origfile->get('field_file_size')->value;
           $download_info .= " " . $origfile->get('field_mime_type')->value;
         }
@@ -189,7 +189,7 @@ class DownloadsBlock extends BlockBase implements ContainerFactoryPluginInterfac
         $sf_file = ($servicefile->hasField($source_field) && (is_object($servicefile->get($source_field)) && $servicefile->get($source_field)->referencedEntities() != NULL) ? $servicefile->get($source_field)->referencedEntities()[0] : FALSE);
         if ($sf_file) {
           $sf_uri = $islandora_utils->getDownloadUrl($sf_file);
-          $sf_link = Link::fromTextAndUrl($this->t('Derivative'), Url::fromUri($sf_uri, ['attributes' => ['class' => ['dropdown-item']]]));
+          $sf_link = Link::fromTextAndUrl($this->t('Derivative'), Url::fromUri($sf_uri, ['attributes' => ['class' => ['dropdown-item'], 'title' => $this->t('Download derivative')]]));
           // $download_info .= $servicefile->get('field_mime_type')->value;
         }
       }
@@ -199,7 +199,7 @@ class DownloadsBlock extends BlockBase implements ContainerFactoryPluginInterfac
       if (!empty($source_field)) {
         $pmf_file = $masterfile->get($source_field)->referencedEntities()[0];
         $pmf_uri = $islandora_utils->getDownloadUrl($pmf_file);
-        $pmf_link = Link::fromTextAndUrl($this->t('Master'), Url::fromUri($pmf_uri, ['attributes' => ['class' => ['dropdown-item']]]));
+        $pmf_link = Link::fromTextAndUrl($this->t('Master'), Url::fromUri($pmf_uri, ['attributes' => ['class' => ['dropdown-item'], 'title' => $this->t('Download original')]]));
         // $download_info .= $masterfile->get('field_mime_type')->value;
       }
     }

--- a/web/modules/custom/asu_item_extras/src/Plugin/Block/FeedbackButton.php
+++ b/web/modules/custom/asu_item_extras/src/Plugin/Block/FeedbackButton.php
@@ -108,7 +108,7 @@ class FeedbackButton extends BlockBase implements ContainerFactoryPluginInterfac
       $feedback_url = Url::fromUri($url_base . '/form/feedback?source_entity_type=node&source_entity_id=' . $nid . '&item=' . $nid . '&collection=' . $cid . '&primary_element=item');
     }
     $link = Link::fromTextAndUrl($this->t('<i class="fas fa-comments"></i> Feedback'), $feedback_url)->toRenderable();
-    $link['#attributes'] = ['class' => $class];
+    $link['#attributes'] = ['class' => $class, 'title' => $this->t('Feedback')];
     $markup = [
       '#markup' => render($link),
     ];

--- a/web/themes/custom/asulib_barrio/asulib_barrio.theme
+++ b/web/themes/custom/asulib_barrio/asulib_barrio.theme
@@ -252,3 +252,12 @@ function asulib_barrio_preprocess_image(&$variables) {
     $variables['attributes']['class'][] = 'card-img-top';
   }
 }
+
+/**
+ * Implements hook_preprocess_views_exposed_form()
+ */
+function asulib_barrio_preprocess_views_exposed_form(&$variables) {
+  if ($variables['form']['#id'] == "views-exposed-form-solr-search-content-page-3") {
+    $variables['form']['actions']['submit']['#attributes']['title'] = 'Search';
+  }
+}

--- a/web/themes/custom/asulib_barrio/asulib_barrio.theme
+++ b/web/themes/custom/asulib_barrio/asulib_barrio.theme
@@ -258,6 +258,9 @@ function asulib_barrio_preprocess_image(&$variables) {
  */
 function asulib_barrio_preprocess_views_exposed_form(&$variables) {
   if ($variables['form']['#id'] == "views-exposed-form-solr-search-content-page-3") {
+    $variables['form']['actions']['submit']['#attributes']['title'] = 'Search collection';
+  }
+  elseif ($variables['form']['#id'] == "views-exposed-form-solr-search-content-page-1") {
     $variables['form']['actions']['submit']['#attributes']['title'] = 'Search';
   }
 }

--- a/web/themes/custom/asulib_barrio/templates/block/block--system-menu-block--main.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/block/block--system-menu-block--main.html.twig
@@ -91,7 +91,7 @@
       </div>
       <div class="navbar-mobile-footer">
         <form class="form-inline navbar-mobile-search" action="https://search.asu.edu/search" method="get" name="gs">
-          <input class="form-control" type="search" name="q" aria-label="Search" placeholder="Search ASU">
+          <input class="form-control" type="search" name="q" aria-label="Search" placeholder="Search ASU" title="Search ASU">
           <input name="site" value="default_collection" type="hidden">
           <input name="sort" value="date:D:L:d1" type="hidden">
           <input name="output" value="xml_no_dtd" type="hidden">

--- a/web/themes/custom/asulib_barrio/templates/field/field--node--field-preferred-citation--asu-repository-item.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/field/field--node--field-preferred-citation--asu-repository-item.html.twig
@@ -57,7 +57,7 @@
   <div{{ attributes.addClass(classes, 'field__item') }}>
     {#<strong>{{ nodetitle }}</strong>#}
     <p>{{ 'This is a suggested citation. Consult the appropriate style guide for specific citation guidelines'|t }}.</p>
-    <p id="citation-text"><strong>{{ item.content }}</strong></p>
-    <button id="copy_citation" class="btn btn-primary btn-md copy_button">Copy citation</button>
+    <p id="citation-text"><strong>{{ item.content|render|striptags }}</strong></p>
+    <button id="copy_citation" class="btn btn-primary btn-md copy_button" title="Copy citation">Copy citation</button>
   </div>
 {% endfor %}

--- a/web/themes/custom/asulib_barrio/templates/field/field--node--field-preferred-citation--asu-repository-item.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/field/field--node--field-preferred-citation--asu-repository-item.html.twig
@@ -57,7 +57,7 @@
   <div{{ attributes.addClass(classes, 'field__item') }}>
     {#<strong>{{ nodetitle }}</strong>#}
     <p>{{ 'This is a suggested citation. Consult the appropriate style guide for specific citation guidelines'|t }}.</p>
-    <p id="citation-text"><strong>{{ item.content|render|striptags }}</strong></p>
+    <div id="citation-text">{{ item.content }}</div>
     <button id="copy_citation" class="btn btn-primary btn-md copy_button" title="Copy citation">Copy citation</button>
   </div>
 {% endfor %}

--- a/web/themes/custom/asulib_barrio/templates/field/field--node--field-preferred-citation--collection.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/field/field--node--field-preferred-citation--collection.html.twig
@@ -57,7 +57,7 @@
   <div{{ attributes.addClass(classes, 'field__item') }}>
     {#<strong>{{ nodetitle }}</strong>#}
     <p>{{ 'This is a suggested citation. Consult the appropriate style guide for specific citation guidelines'|t }}.</p>
-    <p id="citation-text"><strong>{{ item.content }}</strong></p>
-    <button id="copy_citation" class="btn btn-primary btn-md copy_button">Copy citation</button>
+    <p id="citation-text"><strong>{{ item.content|render|striptags }}</strong></p>
+    <button id="copy_citation" class="btn btn-primary btn-md copy_button" title="Copy citation">Copy citation</button>
   </div>
 {% endfor %}

--- a/web/themes/custom/asulib_barrio/templates/field/field--node--field-preferred-citation--collection.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/field/field--node--field-preferred-citation--collection.html.twig
@@ -57,7 +57,7 @@
   <div{{ attributes.addClass(classes, 'field__item') }}>
     {#<strong>{{ nodetitle }}</strong>#}
     <p>{{ 'This is a suggested citation. Consult the appropriate style guide for specific citation guidelines'|t }}.</p>
-    <p id="citation-text"><strong>{{ item.content|render|striptags }}</strong></p>
+    <div id="citation-text">{{ item.content }}</div>
     <button id="copy_citation" class="btn btn-primary btn-md copy_button" title="Copy citation">Copy citation</button>
   </div>
 {% endfor %}

--- a/web/themes/custom/asulib_barrio/templates/field/field--node--field-preferred-citation.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/field/field--node--field-preferred-citation.html.twig
@@ -57,7 +57,7 @@
   <div{{ attributes.addClass(classes, 'field__item') }}>
     {#<strong>{{ nodetitle }}</strong>#}
     <p>{{ 'This is a suggested citation. Consult the appropriate style guide for specific citation guidelines'|t }}.</p>
-    <p id="citation-text"><strong>{{ item.content }}</strong></p>
-    <button id="copy_citation" class="btn btn-primary btn-md copy_button">Copy citation</button>
+    <p id="citation-text"><strong>{{ item.content|render|striptags }}</strong></p>
+    <button id="copy_citation" class="btn btn-primary btn-md copy_button" title="Copy citation">Copy citation</button>
   </div>
 {% endfor %}

--- a/web/themes/custom/asulib_barrio/templates/field/field--node--field-preferred-citation.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/field/field--node--field-preferred-citation.html.twig
@@ -57,7 +57,7 @@
   <div{{ attributes.addClass(classes, 'field__item') }}>
     {#<strong>{{ nodetitle }}</strong>#}
     <p>{{ 'This is a suggested citation. Consult the appropriate style guide for specific citation guidelines'|t }}.</p>
-    <p id="citation-text"><strong>{{ item.content|render|striptags }}</strong></p>
+    <div id="citation-text">{{ item.content }}</div>
     <button id="copy_citation" class="btn btn-primary btn-md copy_button" title="Copy citation">Copy citation</button>
   </div>
 {% endfor %}


### PR DESCRIPTION
_pending approval of the text used_

This feature branch adjusts the buttons that are rendered in several places in order to add a title="some title" attribute to them. Since some of these are in twig files and the rest are adjustments to either the block build() routine or finally changed in a form alter hook, you should be able to see these changes after checking out the branch and clearing the cache.

##### "Copy citation" button:

- To see the adjusted button text, navigate to an item overview page or collection that contains a citation and inspect the button html or hover until the title appears and confirm title = "Copy citation".

##### "Download {type}" button:

- To see the adjusted button text, navigate to an item overview page that has attached media and inspect the various download button options to confirm title = "Download {type}" where {type} is either _original_ or _derivative_.

##### ASU Search button (top nav bar):

- inspect button to see the title = "Search ASU"

##### Search results - refine search button:

- navigate to any site search or collection search results (and optionally even facet the results) and confirm that either button title = "Search" or "Search collection" as appropriate

##### Feedback button:

- navigate to any page that has the Feedback button and confirm that the title = "Feedback"
