### PR TITLE
Comments statistics 530

### DIFF
--- a/web/modules/custom/asu_statistics/asu_statistics.module
+++ b/web/modules/custom/asu_statistics/asu_statistics.module
@@ -7,6 +7,17 @@
 
 /**
  * Implements hook_theme().
+ * 
+ * The asu_statistics_chart template will display the statistics for the entire
+ * site at /admin/reports/asu_statistics item accessions and downloads as well
+ * as a table which breaks down each collection's total size.
+ * 
+ * For each collection, this same template will display the statistics for
+ * all item accessions combined with a breakdown of content types in the
+ * collection at the route /collections/{node}/statistics for all.
+ * 
+ * The logic for populating all of these variables in in the
+ * ASUStatisticsReportController's main() method.
  */
 function asu_statistics_theme($existing, $type, $theme, $path) {
   return [

--- a/web/modules/custom/asu_statistics/asu_statistics.routing.yml
+++ b/web/modules/custom/asu_statistics/asu_statistics.routing.yml
@@ -1,3 +1,5 @@
+# route to show a statisics report which will populate all variables used by
+# the template/asu-statistics-chart.html.twig.
 asu_statistics.settings:
   path: '/admin/reports/asu_statistics'
   defaults:
@@ -7,7 +9,7 @@ asu_statistics.settings:
     _permission: 'administer site configuration'
   options:
     _admin_route: TRUE
-
+# Route for handling the site Item Accessions report "Download CSV" link.
 asu_statistics.statistics_download_accessions:
   path: '/admin/reports/asu_statistics/download'
   defaults:
@@ -17,7 +19,8 @@ asu_statistics.statistics_download_accessions:
     _permission: 'administer site configuration'
   options:
     _admin_route: TRUE
-
+# Route for handling Collection size section of the site report section's
+# "Download CSV" link.
 asu_statistics.statistics_download_stat_summary:
   path: '/admin/reports/asu_statistics/downloadStatSummary'
   defaults:
@@ -27,7 +30,8 @@ asu_statistics.statistics_download_stat_summary:
     _permission: 'administer site configuration'
   options:
     _admin_route: TRUE
-
+# similar to asu_statistics.settings above but for a given collection which
+# will populate all variables used by the template/asu-statistics-chart.html.twig.
 asu_statistics.collection_statistics_view:
   path: '/collections/{node}/statistics'
   defaults:
@@ -40,7 +44,7 @@ asu_statistics.collection_statistics_view:
     parameters:
       node:
         type: entity:node
-
+# Route for handling  given collection's Item Accessions report "Download CSV" link.
 asu_statistics.collection_statistics_download_accessions:
   path: '/collections/{node}/statistics/download'
   defaults:
@@ -52,7 +56,8 @@ asu_statistics.collection_statistics_download_accessions:
     parameters:
       node:
         type: entity:node
-
+# Route for handling Collection size section of the site report section's
+# "Download CSV" link.
 asu_statistics.collection_statistics_download_stat_summary:
   path: '/collections/{node}/statistics/downloadStatSummary'
   defaults:
@@ -64,7 +69,8 @@ asu_statistics.collection_statistics_download_stat_summary:
     parameters:
       node:
         type: entity:node
-
+# Route for handling a given collection's "Content Counts" report report
+# section's "Download CSV" link.
 asu_statistics.collection_statistics_download_downloads_stats:
   path: '/collections/{node}/statistics/downloadDownloadStats'
   defaults:

--- a/web/modules/custom/asu_statistics/src/Access/GroupAccessController.php
+++ b/web/modules/custom/asu_statistics/src/Access/GroupAccessController.php
@@ -61,7 +61,7 @@ class GroupAccessController implements AccessInterface {
     $grp_membership_service = \Drupal::service('group.membership_loader');
     $grps = $grp_membership_service->loadByUser($account);
     $roles = $account->getRoles();
-    $access = (in_array('administrator', $roles));
+    $access = (in_array('administrator', $roles) || in_array('view asu statistics reports', $roles));
     $plugin_id = 'group_node:collection';
     foreach ($grps as $grp) {
       if ($grp) {

--- a/web/modules/custom/asu_statistics/src/Controller/ASUStatisticsReportsController.php
+++ b/web/modules/custom/asu_statistics/src/Controller/ASUStatisticsReportsController.php
@@ -187,10 +187,10 @@ class ASUStatisticsReportsController extends ControllerBase {
     ];
     $summary_row = $total_file_size;
     return [
+      '#theme' => 'asu_statistics_chart',
       '#download_url' => $download_url,
       '#download_stat_summary_url' => $download_stat_summary_url,
       '#download_downloads_url' => $download_downloads_url,
-      '#theme' => 'asu_statistics_chart',
       '#total_items' => $total_items,
       '#stats_table' => $stats_table,
       '#content_counts_table' => $content_counts_table,
@@ -279,7 +279,6 @@ class ASUStatisticsReportsController extends ControllerBase {
     return $this->doCsvDownload($written_filename);
   }
 
-
   /**
    * Will cause the browser to download the given file.
    *
@@ -356,7 +355,7 @@ class ASUStatisticsReportsController extends ControllerBase {
    *   The title value.
    */
   public function getTitle($node = NULL) {
-    return (($node) ? $node->getTitle() . " " : "") . "Statistics";
+    return (($node) ? $node->getTitle() . " - " : "") . "Statistics";
   }
 
   /**


### PR DESCRIPTION
During development, it was noticed that the "View ASU Statistics Reports" permission was never being used anywhere. It was also noticed that the `collections/{nid}/statistics` page title was not separating the word "Statistics" from the actual collection title, making it a little difficult to read -- this has been changed to add a "-" separating character by Jordyn's preference. Without making a separate issue to track these two minor things, they have been rolled into this branch.

Pull down this feature branch and clear cache.

Everything in this branch is merely the addition of some comments here and there. There was also the minor adjustment to the logic only to add permission checking to the access() method of the GroupAccessController. This can be tested by logging in as a user that does not have collection ownership group permissions and attempt to view the collection's statistics page `collections/{nid}/statistics`. Also, while on this page, confirm that the new page title has a "-" separating character between the collection title and the word "Statistics".