### PR TITLE
Nosearch breadcrumb 497

### DIFF
--- a/web/modules/custom/asu_statistics/asu_statistics.module
+++ b/web/modules/custom/asu_statistics/asu_statistics.module
@@ -7,6 +7,17 @@
 
 /**
  * Implements hook_theme().
+ * 
+ * The asu_statistics_chart template will display the statistics for the entire
+ * site at /admin/reports/asu_statistics item accessions and downloads as well
+ * as a table which breaks down each collection's total size.
+ * 
+ * For each collection, this same template will display the statistics for
+ * all item accessions combined with a breakdown of content types in the
+ * collection at the route /collections/{node}/statistics for all.
+ * 
+ * The logic for populating all of these variables in in the
+ * ASUStatisticsReportController's main() method.
  */
 function asu_statistics_theme($existing, $type, $theme, $path) {
   return [

--- a/web/modules/custom/asu_statistics/asu_statistics.routing.yml
+++ b/web/modules/custom/asu_statistics/asu_statistics.routing.yml
@@ -1,3 +1,5 @@
+# route to show a statisics report which will populate all variables used by
+# the template/asu-statistics-chart.html.twig.
 asu_statistics.settings:
   path: '/admin/reports/asu_statistics'
   defaults:
@@ -7,7 +9,7 @@ asu_statistics.settings:
     _permission: 'administer site configuration'
   options:
     _admin_route: TRUE
-
+# Route for handling the site Item Accessions report "Download CSV" link.
 asu_statistics.statistics_download_accessions:
   path: '/admin/reports/asu_statistics/download'
   defaults:
@@ -17,7 +19,8 @@ asu_statistics.statistics_download_accessions:
     _permission: 'administer site configuration'
   options:
     _admin_route: TRUE
-
+# Route for handling Collection size section of the site report section's
+# "Download CSV" link.
 asu_statistics.statistics_download_stat_summary:
   path: '/admin/reports/asu_statistics/downloadStatSummary'
   defaults:
@@ -27,7 +30,8 @@ asu_statistics.statistics_download_stat_summary:
     _permission: 'administer site configuration'
   options:
     _admin_route: TRUE
-
+# similar to asu_statistics.settings above but for a given collection which
+# will populate all variables used by the template/asu-statistics-chart.html.twig.
 asu_statistics.collection_statistics_view:
   path: '/collections/{node}/statistics'
   defaults:
@@ -40,7 +44,7 @@ asu_statistics.collection_statistics_view:
     parameters:
       node:
         type: entity:node
-
+# Route for handling  given collection's Item Accessions report "Download CSV" link.
 asu_statistics.collection_statistics_download_accessions:
   path: '/collections/{node}/statistics/download'
   defaults:
@@ -52,7 +56,8 @@ asu_statistics.collection_statistics_download_accessions:
     parameters:
       node:
         type: entity:node
-
+# Route for handling Collection size section of the site report section's
+# "Download CSV" link.
 asu_statistics.collection_statistics_download_stat_summary:
   path: '/collections/{node}/statistics/downloadStatSummary'
   defaults:
@@ -64,7 +69,8 @@ asu_statistics.collection_statistics_download_stat_summary:
     parameters:
       node:
         type: entity:node
-
+# Route for handling a given collection's "Content Counts" report report
+# section's "Download CSV" link.
 asu_statistics.collection_statistics_download_downloads_stats:
   path: '/collections/{node}/statistics/downloadDownloadStats'
   defaults:

--- a/web/themes/custom/asulib_barrio/asulib_barrio.theme
+++ b/web/themes/custom/asulib_barrio/asulib_barrio.theme
@@ -73,7 +73,7 @@ function asulib_barrio_preprocess_breadcrumb(&$variables) {
           'attributes' => new Attribute(['class' => ['is_active']])
         ];
       }
-      else {
+      elseif ($current_route == "view.solr_search_content.page_1" || $curent_route == "view.solr_search_content.page_3") {
         $variables['breadcrumb'][] = [
           'text' => 'Search',
           'attributes' => new Attribute(['class' => ['is_active']])

--- a/web/themes/custom/asulib_barrio/asulib_barrio.theme
+++ b/web/themes/custom/asulib_barrio/asulib_barrio.theme
@@ -73,6 +73,12 @@ function asulib_barrio_preprocess_breadcrumb(&$variables) {
           'attributes' => new Attribute(['class' => ['is_active']])
         ];
       }
+      else {
+        $variables['breadcrumb'][] = [
+          'text' => 'Search',
+          'attributes' => new Attribute(['class' => ['is_active']])
+        ];
+      }
     }
   }
   $variables['#cache']['contexts'][] = 'url';

--- a/web/themes/custom/asulib_barrio/asulib_barrio.theme
+++ b/web/themes/custom/asulib_barrio/asulib_barrio.theme
@@ -73,7 +73,7 @@ function asulib_barrio_preprocess_breadcrumb(&$variables) {
           'attributes' => new Attribute(['class' => ['is_active']])
         ];
       }
-      elseif ($current_route == "view.solr_search_content.page_1" || $curent_route == "view.solr_search_content.page_3") {
+      elseif ($current_route == "view.solr_search_content.page_1" || $current_route == "view.solr_search_content.page_3") {
         $variables['breadcrumb'][] = [
           'text' => 'Search',
           'attributes' => new Attribute(['class' => ['is_active']])


### PR DESCRIPTION
Pull down this branch and clear the caches.

To confirm the breadcrumb, navigate to the search page without search terms at both: http://localhost:8000/search?search_api_fulltext= and http://localhost:8000/search. See that the breadcrumb reads either "KEEP / Search" or "PRISM / Search" based on which site you're configured for.