### PR TITLE
added link to Explore all items for collection under Latest additions block for #446

### DIFF
--- a/web/modules/custom/asu_collection_extras/src/Plugin/Block/LatestAdditionsToCollectionBlock.php
+++ b/web/modules/custom/asu_collection_extras/src/Plugin/Block/LatestAdditionsToCollectionBlock.php
@@ -103,7 +103,7 @@ class LatestAdditionsToCollectionBlock extends BlockBase implements ContainerFac
     $children_nids = $this->asuUtils->getNodeChildren($collection_node, TRUE, 4);
 
     $rendered_nodes = $this->renderNodes($children_nids);
-    if (count($children_nids) > 4) {
+    if (count($children_nids) > 0) {
       $rendered_nodes .= '<br class="clearfloat"><div><p><strong><a class="btn btn-maroon" href="' .
          '/collections/'. $collection_node->id() . '/search/?search_api_fulltext=">Explore all items</a></strong></p></div>';
     }

--- a/web/modules/custom/asu_collection_extras/src/Plugin/Block/LatestAdditionsToCollectionBlock.php
+++ b/web/modules/custom/asu_collection_extras/src/Plugin/Block/LatestAdditionsToCollectionBlock.php
@@ -103,6 +103,10 @@ class LatestAdditionsToCollectionBlock extends BlockBase implements ContainerFac
     $children_nids = $this->asuUtils->getNodeChildren($collection_node, TRUE, 4);
 
     $rendered_nodes = $this->renderNodes($children_nids);
+    if (count($children_nids) > 3) {
+      $rendered_nodes .= '<br class="clearfloat"><div><p><strong><a class="btn btn-maroon" href="' .
+         '/collections/'. $collection_node->id() . '/search/?search_api_fulltext=">Explore all items</a></strong></p></div>';
+    }
 
     $return = [
       '#cache' => ['max-age' => 0],

--- a/web/modules/custom/asu_collection_extras/src/Plugin/Block/LatestAdditionsToCollectionBlock.php
+++ b/web/modules/custom/asu_collection_extras/src/Plugin/Block/LatestAdditionsToCollectionBlock.php
@@ -103,7 +103,7 @@ class LatestAdditionsToCollectionBlock extends BlockBase implements ContainerFac
     $children_nids = $this->asuUtils->getNodeChildren($collection_node, TRUE, 4);
 
     $rendered_nodes = $this->renderNodes($children_nids);
-    if (count($children_nids) > 3) {
+    if (count($children_nids) > 4) {
       $rendered_nodes .= '<br class="clearfloat"><div><p><strong><a class="btn btn-maroon" href="' .
          '/collections/'. $collection_node->id() . '/search/?search_api_fulltext=">Explore all items</a></strong></p></div>';
     }


### PR DESCRIPTION
This small feature branch only includes a minor adjustment to how the Latest Additions to Collection block is built. The code requires more than 4 items in the collection.

To test, simply pull this branch and clear the cache -- then navigate to a collection overview page that contains more than 4 children and check the link. 

Also, navigate to any collection that does NOT have more than 4 items to see that the link does not appear (since all of the collection items would be displayed in the "Latest")..