### PR TITLE
Fixed html-escaped characters issue for collection teasers

### DIFF
--- a/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--collection-browse-teaser.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--collection-browse-teaser.html.twig
@@ -103,14 +103,14 @@
             {% endif %}
         </div>
         <div class="card-header">
-            <h5{{ title_attributes.addClass('node__title', 'card-title') }}>
-                {% set title = content.field_title[0]|render|trim|slice(0, 40) %}
-                <a href="{{ url }}" rel="bookmark">{{ title|raw }}
-                {% if content.field_title[0]|render|length > 40 %}
-                    ...
-                {% endif %}
-                </a>
-            </h5>
+          <h5{{ title_attributes.addClass('node__title', 'card-title') }}>
+            {% set title = node.label|trim|slice(0, 40) %}
+            <a href="{{ url }}" rel="bookmark">{{ title }}
+            {% if node.label|length > 40 %}
+                ...
+            {% endif %}
+            </a>
+        </h5>
         </div>
     </div>
 {# </div> #}


### PR DESCRIPTION
This resolves #578.  The issue wasn't with _unicode_ characters but with any html-escaped character, which was expanded out prior to getting to the template. Truncating these strings could sometimes cut one of these escaped characters in two, resulting in bad output. In order to get access to the 'pre-escaped' string I had to change the input source from content.field_title to node.label. AFAIK this shouldn't be unsafe, but we should not proceed unless we are reasonably confident this is true.