### PR TITLE
Update to KEEP Share your Work form

### DIFF
--- a/config/sync/webform.webform.self_deposit.yml
+++ b/config/sync/webform.webform.self_deposit.yml
@@ -147,9 +147,9 @@ elements: |-
       '#type': value
       '#title': 'Item Node'
     dataset:
-      '#type': checkbox
-      '#title': 'Do you also have research datasets or supplementary material supporting your submission you need to publish as part of a funder or journal requirement?'
-      '#description': '<a href="https://libguides.asu.edu/data/dataverse">Learn more about research datasets and Dataverse.</a>'
+      '#type': textarea
+      '#title': 'Please indicate how you will archive and share your related researcher data'
+      '#description': '<a href="https://libguides.asu.edu/data/dataverse">Learn more about research datasets and the ASU Research Data Repository.</a>'
       '#title_display': before
       '#description_display': after
   add_files:


### PR DESCRIPTION
Resolves issue tracked on [airtable](https://airtable.com/apprqD9X6qd1EkZuf/tbliRGlWN4LaIIYhd/viwbx6KnAiZSrT0q9/recrdjE9Z4ZPSRiPB/fldnikSB3WpPDMktR?copyLinkToCellOrRecordOrigin=gridView).

Testing instructions: Import Drupal config, then access Share Your Work form, updated field should be displayed at the bottom of the second page. Ensure form submission completes, and that current and previous submissions are properly accessible and in a sane state.