### PR TITLE
Fix for 2023-04 sprint, airtable line 20

### DIFF
--- a/web/themes/custom/asulib_barrio/scss/components/views.scss
+++ b/web/themes/custom/asulib_barrio/scss/components/views.scss
@@ -128,6 +128,9 @@
                 width: auto;
                 max-height: 200px;
                 max-width: 100%;
+                border-style: solid;
+                border-width: thin;
+                border-color: lightgray;
             }
         }
     }


### PR DESCRIPTION
Add border to thumbnail images where white bg masks image edges.  Since no one is really sure what the scss does or how it affects the other styles, I put it in both locations where the matching style is found.