### PR TITLE
Disabled auto-creation of repo item on SYW form submission

### DIFF
--- a/config/sync/webform.webform.self_deposit.yml
+++ b/config/sync/webform.webform.self_deposit.yml
@@ -395,13 +395,4 @@ handlers:
       theme_name: ''
       parameters: {  }
       debug: false
-  create_a_repository_item:
-    id: 'Create a repository item'
-    handler_id: create_a_repository_item
-    label: 'Create a repository item'
-    notes: ''
-    status: true
-    conditions: {  }
-    weight: 0
-    settings: {  }
 variants: {  }


### PR DESCRIPTION
No longer triggers create_a_repository_item handler when submitting share your work form, addressing issue [tracked in airtable](https://airtable.com/apprqD9X6qd1EkZuf/tbliRGlWN4LaIIYhd/viwbx6KnAiZSrT0q9/rechR12WWNu1tb3ER/fldnikSB3WpPDMktR?copyLinkToCellOrRecordOrigin=gridView). Can be tested by creating a dummy submission using the form, the e-mail handler should still work, and the submission object will still be created but the repository item will not.