### PR TITLE
Implement parent field autocomplete for term add/edit form

### DIFF
--- a/config/prism/taxonomy.settings.yml
+++ b/config/prism/taxonomy.settings.yml
@@ -1,3 +1,3 @@
 maintain_index_table: true
-override_selector: false
+override_selector: true
 terms_per_page_admin: 100

--- a/config/sync/taxonomy.settings.yml
+++ b/config/sync/taxonomy.settings.yml
@@ -1,3 +1,3 @@
 maintain_index_table: true
-override_selector: false
+override_selector: true
 terms_per_page_admin: 100

--- a/web/modules/custom/asu_taxonomies/asu_taxonomies.module
+++ b/web/modules/custom/asu_taxonomies/asu_taxonomies.module
@@ -2,20 +2,41 @@
 
 /**
  * @file
+ * Taxonomy hooks.
  */
 
+use Drupal\Core\Entity\EntityFormInterface;
+
 /**
- * Implementation of hook_form_FORM_ID_alter().
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * Overriding the parent selector for taxonomy terms and replacing
+ * the default select list with an auto-complete for improved page
+ * loading performance.
  */
 function asu_taxonomies_form_taxonomy_term_form_alter(&$form, &$form_state, $form_id) {
-  // dsm('Vocab ID: ' . print_r($form['vid'], TRUE));
-  // dsm(print_r($form['relations']['parent'], TRUE));.
+
+  // Load the parent value, if any, to populate the parent form field.
+  $parent_default_value = [];
+  if ($form_state->getFormObject() instanceof EntityFormInterface) {
+    $term = $form_state->getformObject()->getEntity();
+    if ($term->hasField('parent')) {
+      // The form field needs an array of entities,
+      // not an EntityReferenceFieldItemList.
+      foreach ($term->parent as $parent) {
+        $parent_default_value[] = $parent->entity;
+      }
+    }
+  }
+
   $form['relations']['parent'] = [
     '#type' => 'entity_autocomplete',
     '#target_type' => 'taxonomy_term',
     '#tags' => TRUE,
-    // @todo: load current term: `'#default_value' => [],`.
-    '#selection_settings' => ['target_bundles' => [$form['vid']['#value']]],
+    '#default_value' => $parent_default_value,
+    '#selection_settings' => [
+      'target_bundles' => [$form['vid']['#value']],
+    ],
   ];
 
 }

--- a/web/modules/custom/asu_taxonomies/asu_taxonomies.module
+++ b/web/modules/custom/asu_taxonomies/asu_taxonomies.module
@@ -5,6 +5,7 @@
  * Taxonomy hooks.
  */
 
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Entity\EntityFormInterface;
 
 /**
@@ -15,28 +16,43 @@ use Drupal\Core\Entity\EntityFormInterface;
  * loading performance.
  */
 function asu_taxonomies_form_taxonomy_term_form_alter(&$form, &$form_state, $form_id) {
+  // Add a validator that runs *before* the TermForm one.
+  // See the validator below for details.
+  array_unshift($form['#validate'], 'asu_taxonomies_term_autocomplete_validate');
+
+  // Replace the multi-select with entity_autocomplete.
+  $form['relations']['parent'] = [
+    '#type' => 'entity_autocomplete',
+    '#target_type' => 'taxonomy_term',
+    '#tags' => TRUE,
+    '#selection_settings' => [
+      'target_bundles' => [$form['vid']['#value']],
+    ],
+  ];
 
   // Load the parent value, if any, to populate the parent form field.
-  $parent_default_value = [];
   if ($form_state->getFormObject() instanceof EntityFormInterface) {
     $term = $form_state->getformObject()->getEntity();
     if ($term->hasField('parent')) {
       // The form field needs an array of entities,
       // not an EntityReferenceFieldItemList.
       foreach ($term->parent as $parent) {
-        $parent_default_value[] = $parent->entity;
+        if ($parent->entity) {
+          $form['relations']['parent']['#default_value'][] = $parent->entity;
+        }
       }
     }
   }
+}
 
-  $form['relations']['parent'] = [
-    '#type' => 'entity_autocomplete',
-    '#target_type' => 'taxonomy_term',
-    '#tags' => TRUE,
-    '#default_value' => $parent_default_value,
-    '#selection_settings' => [
-      'target_bundles' => [$form['vid']['#value']],
-    ],
-  ];
-
+/**
+ * Fixes empty parent values so TermForm doesn't die.
+ *
+ * An empty entity_autocomplete is simply null. However, TermForm expects
+ * an array. So, we give it an empty array if the parent field is empty.
+ */
+function asu_taxonomies_term_autocomplete_validate(&$form, FormStateInterface $form_state) {
+  if (empty($form_state->getValue('parent'))) {
+    $form_state->setValue('parent', []);
+  }
 }

--- a/web/modules/custom/asu_taxonomies/asu_taxonomies.module
+++ b/web/modules/custom/asu_taxonomies/asu_taxonomies.module
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @file
+ */
+
+/**
+ * Implementation of hook_form_FORM_ID_alter().
+ */
+function asu_taxonomies_form_taxonomy_term_form_alter(&$form, &$form_state, $form_id) {
+  // dsm('Vocab ID: ' . print_r($form['vid'], TRUE));
+  // dsm(print_r($form['relations']['parent'], TRUE));.
+  $form['relations']['parent'] = [
+    '#type' => 'entity_autocomplete',
+    '#target_type' => 'taxonomy_term',
+    '#tags' => TRUE,
+    // @todo: load current term: `'#default_value' => [],`.
+    '#selection_settings' => ['target_bundles' => [$form['vid']['#value']]],
+  ];
+
+}


### PR DESCRIPTION
The taxonomy term add/edit form page was taking up to two minutes to load for large vocabularies such as person. This is due to the default form using `\Drupal\taxonomy\TermStorageInterface::loadTree()`.

This PR uses the taxonomy override_selector configuration to skip loading the whole vocabulary and then replaces the (now empty) parent multi-select list form element with an auto-complete form element.

See https://airtable.com/apprqD9X6qd1EkZuf/tbliRGlWN4LaIIYhd/viwbx6KnAiZSrT0q9/rec0tv9Z5Z06FqpnU?blocks=hide