### PR TITLE
Removed superfluous header in search page which was throwing errors

### DIFF
--- a/config/prism/views.view.solr_search_content.yml
+++ b/config/prism/views.view.solr_search_content.yml
@@ -1193,6 +1193,7 @@ display:
         - 'config:field.storage.node.field_rich_description'
         - 'config:field.storage.node.field_title'
         - 'config:search_api.index.default_solr_index'
+        - 'search_api_list:default_solr_index'
       cacheable: false
   block_1:
     id: block_1
@@ -1635,6 +1636,7 @@ display:
         - 'config:field.storage.node.field_collection_thumbnail'
         - 'config:field.storage.node.field_title'
         - 'config:search_api.index.default_solr_index'
+        - 'search_api_list:default_solr_index'
       cacheable: false
   page_1:
     id: page_1
@@ -1866,17 +1868,6 @@ display:
         footer: false
       relationships: {  }
       header:
-        view:
-          id: view
-          table: views
-          field: view
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: view
-          empty: false
-          view_to_insert: 'solr_search_content:block_1'
-          inherit_arguments: true
         area:
           id: area
           table: views
@@ -1941,6 +1932,7 @@ display:
         - 'config:field.storage.node.field_rich_description'
         - 'config:field.storage.node.field_title'
         - 'config:search_api.index.default_solr_index'
+        - 'search_api_list:default_solr_index'
       cacheable: false
   page_2:
     id: page_2
@@ -2217,6 +2209,7 @@ display:
         - 'config:field.storage.node.field_rich_description'
         - 'config:field.storage.node.field_title'
         - 'config:search_api.index.default_solr_index'
+        - 'search_api_list:default_solr_index'
   page_3:
     id: page_3
     display_title: 'Search Within Collection - Page'
@@ -2492,6 +2485,7 @@ display:
         - 'config:field.storage.node.field_rich_description'
         - 'config:field.storage.node.field_title'
         - 'config:search_api.index.default_solr_index'
+        - 'search_api_list:default_solr_index'
   page_4:
     id: page_4
     display_title: 'OVERRIDE PERMS - Search Within Collection - Page'
@@ -2796,3 +2790,4 @@ display:
         - 'config:field.storage.node.field_rich_description'
         - 'config:field.storage.node.field_title'
         - 'config:search_api.index.default_solr_index'
+        - 'search_api_list:default_solr_index'

--- a/config/sync/views.view.solr_search_content.yml
+++ b/config/sync/views.view.solr_search_content.yml
@@ -1094,6 +1094,7 @@ display:
         - 'config:field.storage.node.field_rich_description'
         - 'config:field.storage.node.field_title'
         - 'config:search_api.index.default_solr_index'
+        - 'search_api_list:default_solr_index'
       cacheable: false
   block_1:
     id: block_1
@@ -1536,6 +1537,7 @@ display:
         - 'config:field.storage.node.field_collection_thumbnail'
         - 'config:field.storage.node.field_title'
         - 'config:search_api.index.default_solr_index'
+        - 'search_api_list:default_solr_index'
       cacheable: false
   page_1:
     id: page_1
@@ -1805,17 +1807,6 @@ display:
         footer: false
       relationships: {  }
       header:
-        view:
-          id: view
-          table: views
-          field: view
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: view
-          empty: false
-          view_to_insert: 'solr_search_content:block_1'
-          inherit_arguments: true
         area:
           id: area
           table: views
@@ -1875,6 +1866,7 @@ display:
         - 'config:field.storage.node.field_rich_description'
         - 'config:field.storage.node.field_title'
         - 'config:search_api.index.default_solr_index'
+        - 'search_api_list:default_solr_index'
       cacheable: false
   page_2:
     id: page_2
@@ -2150,6 +2142,7 @@ display:
         - 'config:field.storage.node.field_rich_description'
         - 'config:field.storage.node.field_title'
         - 'config:search_api.index.default_solr_index'
+        - 'search_api_list:default_solr_index'
   page_3:
     id: page_3
     display_title: 'Search Within Collection - Page'
@@ -2441,6 +2434,7 @@ display:
         - 'config:field.storage.node.field_rich_description'
         - 'config:field.storage.node.field_title'
         - 'config:search_api.index.default_solr_index'
+        - 'search_api_list:default_solr_index'
   page_4:
     id: page_4
     display_title: 'OVERRIDE PERMS - Search Within Collection - Page'
@@ -2741,3 +2735,4 @@ display:
         - 'config:field.storage.node.field_rich_description'
         - 'config:field.storage.node.field_title'
         - 'config:search_api.index.default_solr_index'
+        - 'search_api_list:default_solr_index'


### PR DESCRIPTION
Resolves #553, apparently this was caused by a header in the search page. It was just displaying as a blank grey rectangle, so I see no issue whatsoever with just removing it, in fact it's probably a visual upgrade, visual comparison below. I have absolutely no clue how this caused the error.

Before:
![before](https://github.com/asulibraries/islandora-repo/assets/55711503/27413274-281c-4fcc-a2be-f8df439978f9)

After:
![after](https://github.com/asulibraries/islandora-repo/assets/55711503/dbcc84a5-1372-4549-9cca-2d5588c3172b)


To test, simply import the updated config and run some searches, there should no longer be any error popups.