### PR TITLE
Updated barret submission to only store abstract on parent item for c…

### DIFF
--- a/web/modules/custom/self_deposit/src/Plugin/WebformHandler/CreateBarrettItemWebformHandler.php
+++ b/web/modules/custom/self_deposit/src/Plugin/WebformHandler/CreateBarrettItemWebformHandler.php
@@ -228,10 +228,6 @@ class CreateBarrettItemWebformHandler extends WebformHandlerBase {
           'target_revision_id' => $paragraph->getRevisionId(),
         ],
       ],
-      'field_rich_description' => [
-        'value' => $values['item_description'],
-        'format' => 'description_restricted_items',
-      ],
       'field_reuse_permissions' => [
         ['target_id' => $values['reuse_permissions']],
       ],
@@ -262,6 +258,12 @@ class CreateBarrettItemWebformHandler extends WebformHandlerBase {
     if ($values['number_of_pages'] && $child == FALSE) {
       $node_args['field_extent'] = [
         ['value' => $values['number_of_pages'] . " pages"],
+      ];
+    }
+    if ($values['item_description'] && $child == FALSE) {
+      $node_args['field_rich_description'] = [
+        'value' => $values['item_description'],
+        'format' => 'description_restricted_items',
       ];
     }
     if ($user) {


### PR DESCRIPTION
Resolves issue [tracked on airtable](https://airtable.com/apprqD9X6qd1EkZuf/tbliRGlWN4LaIIYhd/viwbx6KnAiZSrT0q9/recmgGNzC9ZHhe5fX?blocks=hide).

Adds a check for child objects when assigning the abstract (internal name field_rich_description). To test, submit a barrett repo item with multiple files. The provided description is visible on the parent item, but not any of the children.