### PR TITLE
WCAG remediation

### DIFF
--- a/config/prism/views.view.collections.yml
+++ b/config/prism/views.view.collections.yml
@@ -334,7 +334,6 @@ display:
         - 'user.node_grants:view'
       tags:
         - 'config:field.storage.paragraph.field_nonsort'
-        - 'config_split_state:field.storage.paragraph.field_nonsort'
   block_1:
     id: block_1
     display_title: Block
@@ -420,7 +419,6 @@ display:
         - 'user.node_grants:view'
       tags:
         - 'config:field.storage.paragraph.field_nonsort'
-        - 'config_split_state:field.storage.paragraph.field_nonsort'
   collection_top_content:
     id: collection_top_content
     display_title: 'Collection Top Content'
@@ -799,9 +797,6 @@ display:
         - 'config:field.storage.node.field_collaborating_institutions'
         - 'config:field.storage.node.field_collection_thumbnail'
         - 'config:field.storage.node.field_rich_description'
-        - 'config_split_state:field.storage.node.field_collaborating_institutions'
-        - 'config_split_state:field.storage.node.field_collection_thumbnail'
-        - 'config_split_state:field.storage.node.field_rich_description'
   complex_object_top_content:
     id: complex_object_top_content
     display_title: 'Complex Object Top Content'
@@ -1115,8 +1110,6 @@ display:
       tags:
         - 'config:field.storage.node.field_collaborating_institutions'
         - 'config:field.storage.node.field_rich_description'
-        - 'config_split_state:field.storage.node.field_collaborating_institutions'
-        - 'config_split_state:field.storage.node.field_rich_description'
   page_1:
     id: page_1
     display_title: Page
@@ -1586,7 +1579,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: "{% set published_class = [\r\nstatus != \"1\" ? 'node--unpublished',\r\n 'col']\r\n%}\r\n<div class=\"card card-horizontal\">\r\n  {% if field_collection_thumbnail %}\r\n   {{ field_collection_thumbnail }} \r\n  {% endif %}\r\n <div class=\"card-content-wrapper\">\r\n    <div class=\"card-header\">\r\n     <h3 class=\"card-title\">{% if status != \"1\" %}<i class=\"fa fa-lock\"></i> {% endif %}{{ field_title }}</h3>\r\n    </div>\r\n    <div class=\"card-body\">\r\n     <div class=\"card-text\">{{ field_rich_description }}</div>\r\n    </div>\r\n    <div class=\"card-tags\">\r\n     <a role=\"button\" href=\"/collections/{{nid}}\" class=\"btn btn-md btn-gray\">About</a>\r\n     <a role=\"button\" href=\"/collections/{{nid}}/search?search_api_fulltext=\" class=\"btn btn-md btn-gray\">Browse</a>\r\n    </div>\r\n  </div>\r\n</div>"
+            text: "{% set published_class = [\r\nstatus != \"1\" ? 'node--unpublished',\r\n 'col']\r\n%}\r\n<div class=\"card card-horizontal\">\r\n  {% if field_collection_thumbnail %}\r\n   {{ field_collection_thumbnail }} \r\n  {% endif %}\r\n <div class=\"card-content-wrapper\">\r\n    <div class=\"card-header\">\r\n     <h3 class=\"card-title\">{% if status != \"1\" %}<i class=\"fa fa-lock\"></i> {% endif %}{{ field_title }}</h3>\r\n    </div>\r\n    <div class=\"card-body\">\r\n     <div class=\"card-text\">{{ field_rich_description }}</div>\r\n    </div>\r\n    <div class=\"card-tags\">\r\n     <a role=\"button\" href=\"/collections/{{nid}}/search?search_api_fulltext=\" class=\"btn btn-md btn-gray\">Browse</a>\r\n    </div>\r\n  </div>\r\n</div>"
             make_link: false
             path: ''
             absolute: false
@@ -1829,10 +1822,6 @@ display:
         - 'config:field.storage.node.field_rich_description'
         - 'config:field.storage.node.field_title'
         - 'config:field.storage.paragraph.field_nonsort'
-        - 'config_split_state:field.storage.node.field_collection_thumbnail'
-        - 'config_split_state:field.storage.node.field_rich_description'
-        - 'config_split_state:field.storage.node.field_title'
-        - 'config_split_state:field.storage.paragraph.field_nonsort'
   page_2:
     id: page_2
     display_title: Page
@@ -2549,10 +2538,6 @@ display:
         - 'config:field.storage.node.field_rich_description'
         - 'config:field.storage.node.field_title'
         - 'config:field.storage.paragraph.field_nonsort'
-        - 'config_split_state:field.storage.node.field_collection_thumbnail'
-        - 'config_split_state:field.storage.node.field_rich_description'
-        - 'config_split_state:field.storage.node.field_title'
-        - 'config_split_state:field.storage.paragraph.field_nonsort'
   rest_export_1:
     id: rest_export_1
     display_title: 'REST export'
@@ -2829,7 +2814,6 @@ display:
         - 'user.node_grants:view'
       tags:
         - 'config:field.storage.node.field_title'
-        - 'config_split_state:field.storage.node.field_title'
   sub_collections:
     id: sub_collections
     display_title: Sub-Collections
@@ -3301,7 +3285,3 @@ display:
         - 'config:field.storage.node.field_rich_description'
         - 'config:field.storage.node.field_title'
         - 'config:field.storage.paragraph.field_nonsort'
-        - 'config_split_state:field.storage.node.field_collection_thumbnail'
-        - 'config_split_state:field.storage.node.field_rich_description'
-        - 'config_split_state:field.storage.node.field_title'
-        - 'config_split_state:field.storage.paragraph.field_nonsort'

--- a/config/prism/views.view.included_in_complex_object.yml
+++ b/config/prism/views.view.included_in_complex_object.yml
@@ -729,6 +729,423 @@ display:
     display_plugin: block
     position: 2
     display_options:
+      fields:
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_unformatted
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_model:
+          id: field_model
+          table: node__field_model
+          field: field_model
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        nothing:
+          id: nothing
+          table: views
+          field: nothing
+          relationship: none
+          group_type: group
+          admin_label: Thumbnail
+          plugin_id: custom
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: "{%\r\n    set model_icons = {\r\n        \"Image\": \"far fa-file-image\",\r\n        \"Audio\": \"far fa-file-audio\",\r\n        \"Video\": \"far fa-file-video\",\r\n        \"Digital Document\": \"far fa-file-alt\",\r\n        \"Binary\": \"far fa-file\",\r\n        \"Complex Object\": \"complex-object-icon\",\r\n        \"Paged Content\": \"complex-object-icon\",\r\n    }\r\n%}\r\n{% if drupal_view_result('display_media', 'thumbnail', nid) is empty %}\r\n    {% for k, v in model_icons|filter((v, k) => k == field_model) %}\r\n        <div class=\"icon-container\">\r\n            <i class=\"{{ v }} fa-6x\"></i>\r\n        </div>\r\n    {% endfor %}\r\n{% else %}\r\n    {{ drupal_view('display_media', 'thumbnail', nid) }}\r\n{% endif %}"
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: h3
+          element_class: h5
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_handle:
+          id: field_handle
+          table: node__field_handle
+          field: field_handle
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: '<span class="copy_permalink_link" title="{{field_handle__value}}">Permanent Link</span>&nbsp;<span class="copy_permalink_link far fa-copy fa-lg" title="{{field_handle__value}}"></span>'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_linked_agent:
+          id: field_linked_agent
+          table: node__field_linked_agent
+          field: field_linked_agent
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: typed_relation_default
+          settings:
+            link: true
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ' /  '
+          field_api_classes: false
+        nothing_1:
+          id: nothing_1
+          table: views
+          field: nothing
+          relationship: none
+          group_type: group
+          admin_label: 'Display A/V Player'
+          plugin_id: custom
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: "{% if field_model == \"Audio\" or field_model == \"Video\" %}\r\n<div class='av_ajax_player js-view-dom-id-av-player-{{nid}}' data-nid={{nid}}>\r\n  <i class=\"far fa-play-circle\"></i> Load Player\r\n</div>\r\n{% endif %}"
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
       pager:
         type: some
         options:
@@ -738,6 +1155,7 @@ display:
         pager: false
         style: true
         row: true
+        fields: false
       display_description: ''
       display_extenders: {  }
     cache_metadata:

--- a/config/sync/core.menu.static_menu_link_overrides.yml
+++ b/config/sync/core.menu.static_menu_link_overrides.yml
@@ -12,11 +12,11 @@ definitions:
     expanded: false
     enabled: false
   standard__front_page:
+    enabled: false
     menu_name: main
     parent: ''
-    weight: -50
     expanded: false
-    enabled: true
+    weight: -50
   self_deposit__share_your_work:
     menu_name: main
     parent: ''

--- a/config/sync/views.view.collections.yml
+++ b/config/sync/views.view.collections.yml
@@ -334,7 +334,6 @@ display:
         - 'user.node_grants:view'
       tags:
         - 'config:field.storage.paragraph.field_nonsort'
-        - 'config_split_state:field.storage.paragraph.field_nonsort'
   block_1:
     id: block_1
     display_title: Block
@@ -420,7 +419,6 @@ display:
         - 'user.node_grants:view'
       tags:
         - 'config:field.storage.paragraph.field_nonsort'
-        - 'config_split_state:field.storage.paragraph.field_nonsort'
   collection_top_content:
     id: collection_top_content
     display_title: 'Collection Top Content'
@@ -799,9 +797,6 @@ display:
         - 'config:field.storage.node.field_collaborating_institutions'
         - 'config:field.storage.node.field_collection_thumbnail'
         - 'config:field.storage.node.field_rich_description'
-        - 'config_split_state:field.storage.node.field_collaborating_institutions'
-        - 'config_split_state:field.storage.node.field_collection_thumbnail'
-        - 'config_split_state:field.storage.node.field_rich_description'
   complex_object_top_content:
     id: complex_object_top_content
     display_title: 'Complex Object Top Content'
@@ -1115,8 +1110,6 @@ display:
       tags:
         - 'config:field.storage.node.field_collaborating_institutions'
         - 'config:field.storage.node.field_rich_description'
-        - 'config_split_state:field.storage.node.field_collaborating_institutions'
-        - 'config_split_state:field.storage.node.field_rich_description'
   page_1:
     id: page_1
     display_title: Page
@@ -1720,7 +1713,7 @@ display:
           exposed: true
           expose:
             operator_id: combine_op
-            label: ''
+            label: 'Search for collections'
             description: ''
             use_operator: false
             operator: combine_op
@@ -1828,10 +1821,6 @@ display:
         - 'config:field.storage.node.field_rich_description'
         - 'config:field.storage.node.field_title'
         - 'config:field.storage.paragraph.field_nonsort'
-        - 'config_split_state:field.storage.node.field_collection_thumbnail'
-        - 'config_split_state:field.storage.node.field_rich_description'
-        - 'config_split_state:field.storage.node.field_title'
-        - 'config_split_state:field.storage.paragraph.field_nonsort'
   page_2:
     id: page_2
     display_title: Page
@@ -2301,7 +2290,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: "{% set published_class = [\r\nstatus != \"1\" ? 'node--unpublished',\r\n 'col']\r\n%}\r\n<div class=\"card card-horizontal\">\r\n  {% if field_collection_thumbnail %}\r\n   {{ field_collection_thumbnail }} \r\n  {% endif %}\r\n <div class=\"card-content-wrapper\">\r\n    <div class=\"card-header\">\r\n     <h3 class=\"card-title\">{% if status != \"1\" %}<i class=\"fa fa-lock\"></i> {% endif %}{{ field_title }}</h3>\r\n    </div>\r\n    <div class=\"card-body\">\r\n     <div class=\"card-text\">{{ field_rich_description }}</div>\r\n    </div>\r\n    <div class=\"card-tags\">\r\n     <a role=\"button\" href=\"/collections/{{nid}}\" class=\"btn btn-md btn-gray\">About</a>\r\n     <a role=\"button\" href=\"/collections/{{nid}}/search?search_api_fulltext=\" class=\"btn btn-md btn-gray\">Browse</a>\r\n    </div>\r\n  </div>\r\n</div>"
+            text: "{% set published_class = [\r\nstatus != \"1\" ? 'node--unpublished',\r\n 'col']\r\n%}\r\n<div class=\"card card-horizontal\">\r\n  {% if field_collection_thumbnail %}\r\n   {{ field_collection_thumbnail }} \r\n  {% endif %}\r\n <div class=\"card-content-wrapper\">\r\n    <div class=\"card-header\">\r\n     <h3 class=\"card-title\">{% if status != \"1\" %}<i class=\"fa fa-lock\"></i> {% endif %}{{ field_title }}</h3>\r\n    </div>\r\n    <div class=\"card-body\">\r\n     <div class=\"card-text\">{{ field_rich_description }}</div>\r\n    </div>\r\n    <div class=\"card-tags\">\r\n     <a role=\"button\" href=\"/collections/{{nid}}/search?search_api_fulltext=\" class=\"btn btn-md btn-gray\">Browse</a>\r\n    </div>\r\n  </div>\r\n</div>"
             make_link: false
             path: ''
             absolute: false
@@ -2435,7 +2424,7 @@ display:
           exposed: true
           expose:
             operator_id: combine_op
-            label: ''
+            label: 'Search for collections'
             description: ''
             use_operator: false
             operator: combine_op
@@ -2460,7 +2449,7 @@ display:
               honors_student: '0'
               honors_staff: '0'
               some_metadata: '0'
-            placeholder: 'Search for collections'
+            placeholder: ''
           is_grouped: false
           group_info:
             label: 'Combine fields filter'
@@ -2547,10 +2536,6 @@ display:
         - 'config:field.storage.node.field_rich_description'
         - 'config:field.storage.node.field_title'
         - 'config:field.storage.paragraph.field_nonsort'
-        - 'config_split_state:field.storage.node.field_collection_thumbnail'
-        - 'config_split_state:field.storage.node.field_rich_description'
-        - 'config_split_state:field.storage.node.field_title'
-        - 'config_split_state:field.storage.paragraph.field_nonsort'
   rest_export_1:
     id: rest_export_1
     display_title: 'REST export'
@@ -2827,7 +2812,6 @@ display:
         - 'user.node_grants:view'
       tags:
         - 'config:field.storage.node.field_title'
-        - 'config_split_state:field.storage.node.field_title'
   sub_collections:
     id: sub_collections
     display_title: Sub-Collections
@@ -3299,7 +3283,3 @@ display:
         - 'config:field.storage.node.field_rich_description'
         - 'config:field.storage.node.field_title'
         - 'config:field.storage.paragraph.field_nonsort'
-        - 'config_split_state:field.storage.node.field_collection_thumbnail'
-        - 'config_split_state:field.storage.node.field_rich_description'
-        - 'config_split_state:field.storage.node.field_title'
-        - 'config_split_state:field.storage.paragraph.field_nonsort'

--- a/config/sync/views.view.content_recent.yml
+++ b/config/sync/views.view.content_recent.yml
@@ -1975,7 +1975,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: "<div class=\"card card-hover\">\r\n  <div class=\"card-header card-header-icon\">\r\n    <i class=\"far fa-folder-open fa-2x\"></i>\r\n    <h3 class=\"card-title\">{{ field_title }}</h3>\r\n  </div>\r\n  <div class=\"card-body\">\r\n   <a role=\"button\" href=\"/collections/{{nid}}\" class=\"stretched-link\"></a>\r\n   <p class=\"card-text\">\r\n     {{ changed }}\r\n   </p>\r\n  </div>\r\n </div>"
+            text: "<div class=\"card card-hover\">\r\n  <div class=\"card-header card-header-icon\">\r\n    <i class=\"far fa-folder-open fa-2x\"></i>\r\n    <h3 class=\"card-title\">{{ field_title }}</h3>\r\n  </div>\r\n  <div class=\"card-body\">\r\n   <p class=\"card-text\">\r\n     {{ changed }}\r\n   <a role=\"button\" href=\"/collections/{{nid}}\" class=\"sr-only stretched-link\">View Collection</a>\r\n   </p>\r\n  </div>\r\n </div>"
             make_link: false
             path: ''
             absolute: false

--- a/config/sync/views.view.included_in_complex_object.yml
+++ b/config/sync/views.view.included_in_complex_object.yml
@@ -747,6 +747,423 @@ display:
     display_plugin: block
     position: 2
     display_options:
+      fields:
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_unformatted
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_model:
+          id: field_model
+          table: node__field_model
+          field: field_model
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        nothing:
+          id: nothing
+          table: views
+          field: nothing
+          relationship: none
+          group_type: group
+          admin_label: Thumbnail
+          plugin_id: custom
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: "{%\r\n    set model_icons = {\r\n        \"Image\": \"far fa-file-image\",\r\n        \"Audio\": \"far fa-file-audio\",\r\n        \"Video\": \"far fa-file-video\",\r\n        \"Digital Document\": \"far fa-file-alt\",\r\n        \"Binary\": \"far fa-file\",\r\n        \"Complex Object\": \"complex-object-icon\",\r\n        \"Paged Content\": \"complex-object-icon\",\r\n    }\r\n%}\r\n{% if drupal_view_result('display_media', 'thumbnail', nid) is empty %}\r\n    {% for k, v in model_icons|filter((v, k) => k == field_model) %}\r\n        <div class=\"icon-container\">\r\n            <i class=\"{{ v }} fa-6x\"></i>\r\n        </div>\r\n    {% endfor %}\r\n{% else %}\r\n    {{ drupal_view('display_media', 'thumbnail', nid) }}\r\n{% endif %}"
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: h3
+          element_class: h5
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_handle:
+          id: field_handle
+          table: node__field_handle
+          field: field_handle
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: '<span class="copy_permalink_link" title="{{field_handle__value}}">Permanent Link</span>&nbsp;<span class="copy_permalink_link far fa-copy fa-lg" title="{{field_handle__value}}"></span>'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_linked_agent:
+          id: field_linked_agent
+          table: node__field_linked_agent
+          field: field_linked_agent
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: Contributors
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: div
+          element_label_class: field__label
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: typed_relation_brief
+          settings:
+            link: 1
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ' / '
+          field_api_classes: false
+        nothing_1:
+          id: nothing_1
+          table: views
+          field: nothing
+          relationship: none
+          group_type: group
+          admin_label: 'Display A/V Player'
+          plugin_id: custom
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: "{% if field_model == \"Audio\" or field_model == \"Video\" %}\r\n<div class='av_ajax_player js-view-dom-id-av-player-{{nid}}' data-nid={{nid}}>\r\n  <i class=\"far fa-play-circle\"></i> Load Player\r\n</div>\r\n{% endif %}"
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
       pager:
         type: some
         options:
@@ -767,6 +1184,7 @@ display:
         pager: false
         style: false
         row: false
+        fields: false
       display_description: ''
       display_extenders: {  }
     cache_metadata:

--- a/web/modules/custom/asu_brand/src/Plugin/Block/AsuLibFooter.php
+++ b/web/modules/custom/asu_brand/src/Plugin/Block/AsuLibFooter.php
@@ -47,20 +47,25 @@ class AsuLibFooter extends BlockBase {
         <div class="container" id="footer-columns">
           <div class="row">
 
-            <div class="col-xl-3" id="info-column">
-              <h5>' . \Drupal::config('system.site')->get('name') . '</h5>
-              <p class="contact-link"><a href="/contact">Contact Us</a></p>
-              <!--<p class="contribute-button"><a href="#" class="btn btn-small btn-gold">Contribute</a></p>-->
+            <div class="col-xl flex-footer">
+              <div class="card card-foldable desktop-disable-xl">
+                <div class="card-header">
+                  <strong>' . \Drupal::config('system.site')->get('name') . '</strong>
+                </div>
+                <div id="footlink-two" class="collapse card-body show" aria-labelledby="footlink-header-two">
+                  <a class="contact-link nav-link" href="/contact">Contact Us</a>
+                </div>
+              </div>
             </div>
 
             <div class="col-xl flex-footer">
               <div class="card card-foldable desktop-disable-xl">
                 <div class="card-header">
-                  <h5>
+                  <strong>
                     <a id="footlink-header-two" data-toggle="collapse" href="#footlink-two" role="button" aria-expanded="false" aria-controls="footlink-two">Repository Services
                       <i class="fas fa-chevron-up"></i>
                     </a>
-                  </h5>
+                  </strong>
                 </div>
                 <div id="footlink-two" class="collapse card-body show" aria-labelledby="footlink-header-two">
                   <a class="nav-link" href="https://repository.lib.asu.edu" title="Repository Services Home">Home</a>
@@ -74,11 +79,11 @@ class AsuLibFooter extends BlockBase {
             <div class="col-xl flex-footer">
               <div class="card card-foldable desktop-disable-xl">
                 <div class="card-header">
-                  <h5>
+                  <strong>
                     <a id="footlink-header-two" data-toggle="collapse" href="#footlink-two" role="button" aria-expanded="false" aria-controls="footlink-two">Resources
                       <i class="fas fa-chevron-up"></i>
                     </a>
-                  </h5>
+                  </strong>
                 </div>
                 <div id="footlink-two" class="collapse card-body show" aria-labelledby="footlink-header-two">
                   <a class="nav-link" href="https://keep.lib.asu.edu/about/termsofdeposit" title="Terms of Deposit">Terms of Deposit</a>

--- a/web/modules/custom/asu_collection_extras/src/Plugin/Block/LatestAdditionsToCollectionBlock.php
+++ b/web/modules/custom/asu_collection_extras/src/Plugin/Block/LatestAdditionsToCollectionBlock.php
@@ -143,7 +143,7 @@ class LatestAdditionsToCollectionBlock extends BlockBase implements ContainerFac
       $build = $view_builder->view($node, 'collection_browse_teaser');
       $output[] = render($build);
     }
-    return '<div class="card-deck">' . implode('', $output) . "</div>";
+    return '<div class="row">' . implode('', $output) . "</div>";
   }
 
 }

--- a/web/modules/custom/asu_item_extras/src/Plugin/Block/ASUAltmetrics.php
+++ b/web/modules/custom/asu_item_extras/src/Plugin/Block/ASUAltmetrics.php
@@ -3,11 +3,11 @@
 namespace Drupal\asu_item_extras\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
-use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Routing\CurrentRouteMatch;
 use Drupal\Core\Cache\Cache;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Routing\CurrentRouteMatch;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides an 'Altmetrics' Block.
@@ -125,7 +125,7 @@ class ASUAltmetrics extends BlockBase implements ContainerFactoryPluginInterface
     }
     $handle = $node->field_handle->value;
     if ($doi_val) {
-      $altmetrics_embed = ' data-doi="' . $doi_val . '"';
+      $altmetrics_embed['data-doi'] = $doi_val;
     }
     elseif ($handle) {
       if (strstr($handle, "://")) {
@@ -135,33 +135,30 @@ class ASUAltmetrics extends BlockBase implements ContainerFactoryPluginInterface
           $urlparts['path'] : "");
         $handle = ltrim($handle, "/");
       }
-      $altmetrics_embed = ' data-handle="' . $handle . '"';
+      $altmetrics_embed['data-handle'] = $handle;
     }
     else {
-      $altmetrics_embed = '';
+      $altmetrics_embed = [];
     }
-    return (($altmetrics_embed) ?
+    return (!empty($altmetrics_embed) ?
       [
         '#type' => 'container',
         'altmetrics-container' => [
-          '#type' => 'item',
+          '#type' => 'container',
           '#id' => 'altmetrics_box',
-          'container' => [
+          '#attached' => [
+            'library' => [
+              'asu_item_extras/altmetrics',
+            ],
+          ],
+          'data-badge' => [
             '#type' => 'container',
-            'left-block' => [
-              '#type' => 'item',
-              '#markup' => '<div data-badge-popover="right" data-badge-type="2"' .
-              $altmetrics_embed . ' data-hide-no-mentions="true" class="altmetric-embed"></div>',
-            ],
-              // Need the javascript to be attached to the render elements.
-            'right-block' => [
-              '#type' => 'item',
-              '#attached' => [
-                'library' => [
-                  'asu_item_extras/altmetrics',
-                ],
-              ],
-            ],
+            '#attributes' => array_merge($altmetrics_embed, [
+              'data-badge-popover' => 'right',
+              'data-badge-type' => '2',
+              'data-hide-no-mentions' => 'true',
+              'class' => ['altmetric-embed'],
+            ]),
           ],
         ],
       ] : []);

--- a/web/modules/custom/asu_item_extras/src/Plugin/Block/ASUItemIIIF.php
+++ b/web/modules/custom/asu_item_extras/src/Plugin/Block/ASUItemIIIF.php
@@ -128,6 +128,7 @@ class ASUItemIIIF extends BlockBase implements ContainerFactoryPluginInterface {
           '#attributes' => ['class' => ['col-md-9', 'offset-md-1']],
           'iiif-link-field' => [
             '#type' => 'textfield',
+            '#title' => $this->t('Item IIIF Manifest URL'),
             '#id' => 'iiif_editbox' . $id_suffix,
             '#value' => str_replace('/items', '/node', $this->requestStack->getCurrentRequest()->getSchemeAndHttpHost() . $url->toString()) . '/manifest',
           ],

--- a/web/modules/custom/asu_item_extras/src/Plugin/Block/ASUItemIIIF.php
+++ b/web/modules/custom/asu_item_extras/src/Plugin/Block/ASUItemIIIF.php
@@ -3,10 +3,10 @@
 namespace Drupal\asu_item_extras\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
-use Drupal\Core\Url;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
+use Drupal\Core\Url;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Provides a 'International Image Interoperability Framework' Block.
@@ -111,42 +111,29 @@ class ASUItemIIIF extends BlockBase implements ContainerFactoryPluginInterface {
     $id_suffix = !($id_suffix) ? '' : $id_suffix + 1;
     return [
       'iiif-container' => [
-        '#type' => 'item',
+        '#type' => 'container',
         '#id' => 'iiif_box',
-        'container' => [
+        '#attributes' => ['class' => ['row']],
+        'left-block' => [
           '#type' => 'container',
-          'left-block' => [
-            '#type' => 'item',
-            '#prefix' => '<div class="row"><div class="col-md-2">',
-            '#suffix' => '</div>',
-            '#markup' => '            <a class="icon-link" href="https://iiif.io/technical-details/" target="_blank">
+          '#attributes' => ['class' => ['col-md-2']],
+          '#markup' => '            <a class="icon-link" href="https://iiif.io/technical-details/" target="_blank">
                 <img class="img" src="' .
-            $this->requestStack->getCurrentRequest()->getSchemeAndHttpHost() . "/" .
-            drupal_get_path("module", "asu_item_extras") . '/images/IIIF-logo-colored-text.svg">
-              </a>',
-          ],
+          $this->requestStack->getCurrentRequest()->getSchemeAndHttpHost() . "/" .
+          drupal_get_path("module", "asu_item_extras") . '/images/IIIF-logo-colored-text.svg" alt="IIIF logo"></a>',
+        ],
           // Drupal requires javascript to be attached to the render elements.
-          'right-block' => [
-            '#type' => 'item',
-            '#attached' => [
-              'library' => [
-                'asu_item_extras/interact',
-              ],
-            ],
-            'input-box' => [
-              '#type' => 'textfield',
-              '#id' => 'iiif_editbox' . $id_suffix,
-              '#value' => str_replace('/items', '/node', $this->requestStack->getCurrentRequest()->getSchemeAndHttpHost() . $url->toString()) . '/manifest',
-            ],
-            '#prefix' => '<div class="col-md-6 offset-md-1"><p>We support the <a href="https://iiif.io/technical-details/" target="_blank">IIIF</a> Presentation API</p><div class="row no-gutters"><div class="col-9">',
-            '#suffix' => '<!-- Unnamed (Rectangle) -->
-            </div>
-            <div class="col">
-              <a id="copy_manifest_link" class="btn btn-maroon btn-md">Copy link</a>
-            </div>
-            </div>
-            </div>
-          </div>',
+        'right-block' => [
+          '#type' => 'container',
+          '#attributes' => ['class' => ['col-md-9', 'offset-md-1']],
+          'iiif-link-field' => [
+            '#type' => 'textfield',
+            '#id' => 'iiif_editbox' . $id_suffix,
+            '#value' => str_replace('/items', '/node', $this->requestStack->getCurrentRequest()->getSchemeAndHttpHost() . $url->toString()) . '/manifest',
+          ],
+          // We attempted a link type but it wouldn't render, so markup instead.
+          'copy-button' => [
+            '#markup' => '<a id="copy_manifest_link" class="btn btn-maroon btn-md">Copy link</a>',
           ],
         ],
       ],

--- a/web/modules/custom/asu_item_extras/templates/asu-item-extras-downloads-block.html.twig
+++ b/web/modules/custom/asu_item_extras/templates/asu-item-extras-downloads-block.html.twig
@@ -9,6 +9,6 @@
 	<br/>
 	{{ asu_download_restricted }}
 {% elseif asu_download_links is not empty %}
-	<h5>Downloads</h5>
+	<div class="field__label">Downloads</div>
 	{{ asu_download_links }}
 {% endif %}

--- a/web/modules/custom/asu_search/asu_search.module
+++ b/web/modules/custom/asu_search/asu_search.module
@@ -129,13 +129,13 @@ function asu_search_preprocess_views_view(&$variables) {
           unset($variables['header']['view']);
         }
       }
-      // Replace the numeric part with the formatted numeric part in h2.
+      // Replace the numeric part with the formatted numeric part in h1.
       if (array_key_exists('area', $variables['header'])) {
         preg_match_all("/\([^\]]*\)/", strip_tags($variables['header']['area']['#text']), $matches);
         if (is_array($matches) && array_key_exists(0, $matches) && array_key_exists(0, $matches[0])) {
           $item_count = number_format(str_replace(['(', ')'], '', ($matches[0][0])));
-          $variables['header']['area']['#text'] = '<h2 class="search-header">Matching Items (' .
-            $item_count . ')</h2>';
+          $variables['header']['area']['#text'] = '<h1 class="h1 search-header">Matching Items (' .
+            $item_count . ')</h1>';
         }
       }
       // Also do this in the results summary if it is displayed.

--- a/web/modules/custom/asu_search/src/Plugin/Block/ASUComplexTitle.php
+++ b/web/modules/custom/asu_search/src/Plugin/Block/ASUComplexTitle.php
@@ -72,7 +72,7 @@ class ASUComplexTitle extends BlockBase {
       }
       return [
         'complex_title' => [
-          '#type' => 'item',
+          '#type' => 'container',
           '#markup' => implode("<br/>", $rendered_titles),
         ],
       ];

--- a/web/themes/custom/asulib_barrio/templates/block/block--system-menu-block--main.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/block/block--system-menu-block--main.html.twig
@@ -86,7 +86,9 @@
           {{ content }}
         {% endblock %}
 
+      {% if '/search' not in path('<current>')|render|render %}
       {{ drupal_block('search_form_block')}}
+      {% endif %}
 
       </div>
       <div class="navbar-mobile-footer">

--- a/web/themes/custom/asulib_barrio/templates/block/block--system-menu-block--main.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/block/block--system-menu-block--main.html.twig
@@ -91,7 +91,8 @@
       </div>
       <div class="navbar-mobile-footer">
         <form class="form-inline navbar-mobile-search" action="https://search.asu.edu/search" method="get" name="gs">
-          <input class="form-control" type="search" name="q" aria-label="Search" placeholder="Search ASU" title="Search ASU">
+          <input id="mobile-search-asu" class="form-control" type="search" name="q" aria-label="Search" placeholder="Search ASU" title="Search ASU">
+          <label for="mobile-search-asu" class="sr-only">Search ASU</label>
           <input name="site" value="default_collection" type="hidden">
           <input name="sort" value="date:D:L:d1" type="hidden">
           <input name="output" value="xml_no_dtd" type="hidden">

--- a/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--collection-browse-teaser.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--collection-browse-teaser.html.twig
@@ -70,7 +70,7 @@
     not node.isPublished() ? 'node--unpublished',
     view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
     'card',
-    'col-3'
+    'col-lg-3 col-md-4 col-sm-6 col-xs-12'
 ]
 %}
 
@@ -86,7 +86,6 @@
     }
 
 %}
-{# <div class="col-md-3"> #}
     <div {{ attributes.addClass(classes) }}>
         <div{{content_attributes.addClass('node__content','card-img-top')}}>
             {% if complex_obj_thumb is not empty %}
@@ -103,14 +102,15 @@
             {% endif %}
         </div>
         <div class="card-header">
-          <h5{{ title_attributes.addClass('node__title', 'card-title') }}>
+          <h3{{ title_attributes.addClass('node__title', 'card-title') }}>
             {% set title = node.label|trim|slice(0, 40) %}
-            <a href="{{ url }}" rel="bookmark">{{ title }}
+            {{ title }}
             {% if node.label|length > 40 %}
                 ...
             {% endif %}
-            </a>
-        </h5>
+          </h3>
+        </div>
+        <div class="card-body">
+          <a href="{{ url }}" class="stretched-link" rel="bookmark">View Item</a>
         </div>
     </div>
-{# </div> #}

--- a/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--recent-item-teaser.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/content/node--asu-repository-item--recent-item-teaser.html.twig
@@ -106,11 +106,12 @@
 		</h3>
 	</div>
 	<div class="card-body">
-        <a role="button" href="/items/{{ node.id }}" class="stretched-link"></a>
-		{%  if changed_ago %}
-			<p class="card-text">{{ changed_ago }}
-				ago</p>
-		{% endif %}
-	</div>
+          <p class="card-text">
+            {%  if changed_ago %}
+              {{ changed_ago }} ago
+            {% endif %}
+            <a role="button" href="/items/{{ node.id }}" class="sr-only-focusable stretched-link">View Item</a>
+          </p>
+        </div>
 </div>
 

--- a/web/themes/custom/asulib_barrio/templates/field/field--node--field-edtf-date-created.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/field/field--node--field-edtf-date-created.html.twig
@@ -70,7 +70,7 @@
       {{ label }}
       <div class="uds-tooltip-container">
         <button aria-describedby="tooltip-desc-1" class="uds-tooltip uds-tooltip-white" tabindex="0">
-          <i class="fas fa-info-circle"> &nbsp;</i>
+          <i class="fas fa-info-circle"><span class="sr-only">i</span></i>
         </button>
         <div class="uds-tooltip-description" id="tooltip-desc-1" role="tooltip">
           The date the item was original created (prior to any relationship with the ASU Digital Repositories.)

--- a/web/themes/custom/asulib_barrio/templates/field/field--node--field-preferred-citation--asu-repository-item.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/field/field--node--field-preferred-citation--asu-repository-item.html.twig
@@ -58,6 +58,6 @@
     {#<strong>{{ nodetitle }}</strong>#}
     <p>{{ 'This is a suggested citation. Consult the appropriate style guide for specific citation guidelines'|t }}.</p>
     <div id="citation-text">{{ item.content }}</div>
-    <button id="copy_citation" class="btn btn-primary btn-md copy_button" title="Copy citation">Copy citation</button>
+    <button id="copy_citation" class="btn btn-primary btn-md copy_button">Copy citation</button>
   </div>
 {% endfor %}

--- a/web/themes/custom/asulib_barrio/templates/field/taxonomy-term--copyright-statements.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/field/taxonomy-term--copyright-statements.html.twig
@@ -56,7 +56,7 @@
         {{ content_rendered }}
       </div>
     {% else %}
-      <a href="{{content.field_source[0]}}" target="_blank" class="image-link"><img class="copyright-logo" src="{{content.field_copyright_logo[0]}}"/></a>
+      <a href="{{content.field_source[0]}}" target="_blank" class="image-link"><img class="copyright-logo" alt="{{name[0]['#context']['value']}}" src="{{content.field_copyright_logo[0]}}"/></a>
     {% endif %}
 	{% endif %}
 

--- a/web/themes/custom/asulib_barrio/templates/field/taxonomy-term--reuse-permissions.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/field/taxonomy-term--reuse-permissions.html.twig
@@ -58,7 +58,7 @@
       </div>
     {% else %}
       {% if content.field_copyright_logo[0] is not empty %}
-        <a href="{{content.field_source[0]}}" target="_blank" class="image-link"><img class="reuse-logo" src="{{content.field_copyright_logo[0]}}"/></a>
+        <a href="{{content.field_source[0]}}" target="_blank" class="image-link"><img class="reuse-logo" alt="{{name[0]['#context']['value']}}" src="{{content.field_copyright_logo[0]}}"/></a>
       {% elseif content.field_source[0] is not empty %}
         <a href="{{content.field_source[0]}}" target="_blank">{{ name }}</a>
       {% else %}

--- a/web/themes/custom/asulib_barrio/templates/layout/html.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/layout/html.html.twig
@@ -1,0 +1,49 @@
+{#
+/**
+ * @file
+ * Theme override for the basic structure of a single Drupal page.
+ *
+ * Variables:
+ * - logged_in: A flag indicating if user is logged in.
+ * - root_path: The root path of the current page (e.g., node, admin, user).
+ * - node_type: The content type for the current node, if the page is a node.
+ * - head_title: List of text elements that make up the head_title variable.
+ *   May contain or more of the following:
+ *   - title: The title of the page.
+ *   - name: The name of the site.
+ *   - slogan: The slogan of the site.
+ * - page_top: Initial rendered markup. This should be printed before 'page'.
+ * - page: The rendered page markup.
+ * - path_info.args: Array of URL arguments un aliassed.
+ * - page_bottom: Closing rendered markup. This variable should be printed after
+ *   'page'.
+ * - db_offline: A flag indicating if the database is offline.
+ * - placeholder_token: The token for generating head, css, js and js-bottom
+ *   placeholders.
+ *
+ * @see template_preprocess_html()
+ */
+#}
+{%
+  set body_classes = [
+    logged_in ? 'user-logged-in',
+    not root_path ? 'path-frontpage' : 'path-' ~ root_path|clean_class,
+    node_type ? 'node--type-' ~ node_type|clean_class,
+    db_offline ? 'db-offline',
+  ]
+%}
+<!DOCTYPE html>
+<html{{ html_attributes }}>
+  <head>
+    <head-placeholder token="{{ placeholder_token|raw }}">
+    <title>{{ head_title|safe_join(' | ') }}</title>
+    <css-placeholder token="{{ placeholder_token|raw }}">
+    <js-placeholder token="{{ placeholder_token|raw }}">
+  </head>
+  <body{{ attributes.addClass(body_classes) }}>
+    {{ page_top }}
+    {{ page }}
+    {{ page_bottom }}
+    <js-bottom-placeholder token="{{ placeholder_token|raw }}">
+  </body>
+</html>

--- a/web/themes/custom/asulib_barrio/templates/pager.html.twig
+++ b/web/themes/custom/asulib_barrio/templates/pager.html.twig
@@ -31,7 +31,7 @@
 #}
 {% if items %}
   <nav aria-label="{{ heading_id }}">
-    <h4 id="{{ heading_id }}" class="sr-only">{{ 'Pagination'|t }}</h4>
+    <h2 id="{{ heading_id }}" class="h4 sr-only">{{ 'Pagination'|t }}</h2>
     <ul class="pagination js-pager__items">
       {# Print first item if we are not on the first page. #}
       {% if items.first %}


### PR DESCRIPTION
Addresses [WCAG remediation items identified earlier](https://github.com/asulibraries/repository-one-offs/blob/main/2023-06_wcag_audit/work_items.md).

# Headers and Footers
Headers and footers are mostly governed by [asu_header (unity_header)](https://github.com/asulibraries/unity_header/tree/de69a22e259b1db505cc69a243526b1f822e3590) which relies on deprecated `@asu-design-system/bootstrap4-theme` which, even worse, I can't get a working gulp build for. This means that any changes requiring CSS modifications must be postponed until we do a larger theme refresh. That said, purely twig fixes are being added to a [new wcag_fixes branch](https://github.com/asulibraries/unity_header/tree/wcag_fixes).

We use the link TwigExtension which adds the title attribute. How and where is burried in Drupal/Twig internals. I attempted to manually create the links, but I can't get the menu item `sr-only` and `sr-only-focusable` attributes to populate.

Adding legends to fieldsets is proving challenging as it appears to be generated by Drupal internals. Need to look at this more closely.

What we can fix:
  - Empty sign-in link
  - Orphaned 'header-top-search' form input label.
  - ASU Search orphaned label https://github.com/asulibraries/islandora-repo/commit/2bc8e110803351799532a4d71cd45381646ad71a#diff-dfc1acafd316fc888372076a60dfc2df55d68125403c4c66fe5fc3332c618978
  - Dropped the "Skip to main content link" (https://github.com/asulibraries/islandora-repo/commit/2bc8e110803351799532a4d71cd45381646ad71a#diff-823d1cffc63cc799dbc92eef16569ca8177cd181482194d345207fd975c83507) as it was redundant to the link in the global header.
  - Footer header level jump
  - Recent items (https://github.com/asulibraries/islandora-repo/commit/75308437d405e26c0090e3ba916191c6862e3e56) and collection (`/admin/structure/views/view/content_recent/edit/block_5`) empty links. The former being a twig template change and the latter being a views custom text twig.

# Front Page

  - Add empty alt text to KEEP HERO: `https://keep-qa.lib.asu.edu/block/1?destination=/admin/structure/block/block-content`

_Lost notes on progress._

# Search Page

_Lost notes on early progress._

- The duplicated search form in the header causes duplicate form input/label errors on search pages. Sent a message on Slack and stakeholders decided we can remove the search box in the header on search pages. https://github.com/asulibraries/islandora-repo/commit/dd96d0590d00392226ceba31060ce79092fd53c7
- Skipped header level: https://github.com/asulibraries/islandora-repo/commit/dedfc12d46233567bd0f2827ac51dddf3865d47b

# Browse Collections

Missing alt text is a manual data entry issue.

Same fieldset issue.

Fixed redundant link and search label in the view config. 4e915555

# ASU Repository Item Pages (Collections and Items)

Missing image alt text needs to be added manually for each image.

  - Heading level (along with bonus latest item responsiveness) addressed with https://github.com/asulibraries/islandora-repo/commit/4fcbe8962741bc1716e8a413d0995aee8f65c0cc
  - IIIF issues addressed with https://github.com/asulibraries/islandora-repo/commit/07fd849f446aae0978623a7fd90b9be5a2b5c811 & https://github.com/asulibraries/islandora-repo/commit/dc23b7f9994068be5cba569f91ca2736b8169fbe
  - Altmetrics remediation https://github.com/asulibraries/islandora-repo/commit/c960602099f3eb295c00a554ae4ac32e6fb67a03
  - Downloads level jump https://github.com/asulibraries/islandora-repo/commit/cfbaa549c54682ac6e137d3b7f14728d94d7f3a2
  - Copyright and Reuse icon alt text https://github.com/asulibraries/islandora-repo/commit/ad6809569560c44d463237cd1c6be4c37b00de83
  - Citation button duplicated title text aa93e904c1b44894f07293d8dd05fe00825f8832
  - Tool-tip fix https://github.com/asulibraries/islandora-repo/commit/198c498e0775952e615e223d915533fc9ce4e8a9

# Future Work
Honestly, theming is a bit of a mess for the repositories right now. Part of this is that the University provided theming has shifted to Bootstrap 5 while we are still on 4.

# Resources

  - [Unity Upgrade from Bootstrap 4 to Bootstrap 5](https://docs.google.com/document/d/14i4aY_sVg_eERZvbRBIGY1a5efO2-r0zFPTleAWOpoA/edit#heading=h.wpppo5fpz210)
