### PR TITLE
Main Search Revisions

### DIFF
--- a/config/prism/search_api.index.default_solr_index.yml
+++ b/config/prism/search_api.index.default_solr_index.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.storage.node.field_additional_memberships
     - field.storage.node.field_member_of
+    - field.storage.node.field_complex_object_child
     - field.storage.node.field_edtf_copyright_date
     - field.storage.node.field_copyright_statement
     - field.storage.node.field_linked_agent
@@ -170,6 +171,36 @@ field_settings:
     property_path: complex_title
     type: text
     boost: 5.0
+  component_agent_name:
+    label: 'Component Agent Name'
+    datasource_id: 'entity:node'
+    property_path: 'search_api_reverse_entity_references_node__field_member_of:field_linked_agent:entity:name'
+    type: text
+  component_geographic_subject:
+    label: 'Component Geographic Subject'
+    datasource_id: 'entity:node'
+    property_path: 'search_api_reverse_entity_references_node__field_member_of:field_geographic_subject:entity:name'
+    type: text
+  component_temporal_subject:
+    label: 'Component Temporal Subject'
+    datasource_id: 'entity:node'
+    property_path: 'search_api_reverse_entity_references_node__field_member_of:field_temporal_subject:entity:name'
+    type: text
+  component_title:
+    label: 'Component Title'
+    datasource_id: 'entity:node'
+    property_path: 'search_api_reverse_entity_references_node__field_member_of:title'
+    type: text
+  component_title_subject:
+    label: 'Component Title Subject'
+    datasource_id: 'entity:node'
+    property_path: 'search_api_reverse_entity_references_node__field_member_of:field_title_subject:entity:name'
+    type: text
+  component_topical_subject:
+    label: 'Component Topical Subject'
+    datasource_id: 'entity:node'
+    property_path: 'search_api_reverse_entity_references_node__field_member_of:field_subject:entity:name'
+    type: text
   created:
     label: 'Authored on'
     datasource_id: 'entity:node'
@@ -178,6 +209,16 @@ field_settings:
     dependencies:
       module:
         - node
+  descendant_extracted_text:
+    label: 'Descendant Extracted Text'
+    property_path: descendant_extracted_text
+    type: text
+    configuration:
+      bundles:
+        asu_repository_item: asu_repository_item
+        article: 0
+        collection: 0
+        page: 0
   document_uri:
     label: 'Document URI'
     datasource_id: 'entity:node'
@@ -212,6 +253,14 @@ field_settings:
       fields:
         - 'entity:node/field_additional_memberships'
         - 'entity:node/field_member_of'
+  field_complex_object_child:
+    label: 'Complex Object Child'
+    datasource_id: 'entity:node'
+    property_path: field_complex_object_child
+    type: boolean
+    dependencies:
+      config:
+        - field.storage.node.field_complex_object_child
   field_copyright_statement:
     label: 'Copyright Statement'
     datasource_id: 'entity:node'
@@ -696,6 +745,8 @@ processor_settings:
     weights:
       preprocess_index: 5
   complex_title: {  }
+  custom_value: {  }
+  descendant_extracted_text: {  }
   entity_type: {  }
   etdf_created_year_only: {  }
   hierarchy:

--- a/config/prism/views.view.solr_search_content.yml
+++ b/config/prism/views.view.solr_search_content.yml
@@ -993,7 +993,7 @@ display:
         type: none
         options: {  }
       cache:
-        type: none
+        type: search_api_none
         options: {  }
       empty:
         area:
@@ -1849,6 +1849,44 @@ display:
           parse_mode: terms
           min_length: null
           fields: {  }
+        field_complex_object_child:
+          id: field_complex_object_child
+          table: search_api_index_default_solr_index
+          field: field_complex_object_child
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_boolean
+          operator: '!='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:
@@ -1961,7 +1999,7 @@ display:
             offset_label: Offset
           quantity: 7
       cache:
-        type: none
+        type: search_api_none
       sorts:
         search_api_relevance:
           id: search_api_relevance
@@ -2236,7 +2274,7 @@ display:
             offset_label: Offset
           quantity: 5
       cache:
-        type: none
+        type: search_api_none
       sorts:
         search_api_relevance:
           id: search_api_relevance
@@ -2518,7 +2556,7 @@ display:
             metadata_manager: metadata_manager
             some_m: some_m
       cache:
-        type: none
+        type: search_api_none
       sorts:
         search_api_relevance:
           id: search_api_relevance

--- a/config/sync/search_api.index.default_solr_index.yml
+++ b/config/sync/search_api.index.default_solr_index.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.storage.node.field_additional_memberships
     - field.storage.node.field_member_of
+    - field.storage.node.field_complex_object_child
     - field.storage.node.field_edtf_copyright_date
     - field.storage.node.field_copyright_statement
     - field.storage.node.field_linked_agent
@@ -43,7 +44,6 @@ dependencies:
     - field.storage.node.field_title_subject
     - field.storage.node.field_subject
     - search_api.server.default_solr_server
-    - core.entity_view_mode.node.full_metadata
   module:
     - search_api_solr
     - node
@@ -155,11 +155,54 @@ field_settings:
     dependencies:
       module:
         - node
+  complex_object_child:
+    label: 'Complex Object Child'
+    datasource_id: 'entity:node'
+    property_path: field_complex_object_child
+    type: boolean
+    dependencies:
+      config:
+        - field.storage.node.field_complex_object_child
   complex_title:
     label: 'Complex Title'
     property_path: complex_title
     type: text
     boost: 5.0
+  component_agent_name:
+    label: 'Component Agent Name'
+    datasource_id: 'entity:node'
+    property_path: 'search_api_reverse_entity_references_node__field_member_of:field_linked_agent:entity:name'
+    type: text
+  component_geographic_subject:
+    label: 'Component Geographic Subject'
+    datasource_id: 'entity:node'
+    property_path: 'search_api_reverse_entity_references_node__field_member_of:field_geographic_subject:entity:name'
+    type: text
+  component_statement_responsibility:
+    label: 'Component Statement of Responsibility'
+    datasource_id: 'entity:node'
+    property_path: 'search_api_reverse_entity_references_node__field_member_of:field_statement_responsibility'
+    type: text
+  component_temporal_subject:
+    label: 'Component Temporal Subject'
+    datasource_id: 'entity:node'
+    property_path: 'search_api_reverse_entity_references_node__field_member_of:field_temporal_subject:entity:name'
+    type: text
+  component_title:
+    label: 'Component Title'
+    datasource_id: 'entity:node'
+    property_path: 'search_api_reverse_entity_references_node__field_member_of:title'
+    type: text
+  component_title_subject:
+    label: 'Component Title Subject'
+    datasource_id: 'entity:node'
+    property_path: 'search_api_reverse_entity_references_node__field_member_of:field_title_subject:entity:name'
+    type: text
+  component_topical_subject:
+    label: 'Component Topical Subject'
+    datasource_id: 'entity:node'
+    property_path: 'search_api_reverse_entity_references_node__field_member_of:field_subject:entity:name'
+    type: text
   created:
     label: 'Authored on'
     datasource_id: 'entity:node'
@@ -168,6 +211,17 @@ field_settings:
     dependencies:
       module:
         - node
+  descendant_extracted_text:
+    label: 'Descendant Extracted Text'
+    property_path: descendant_extracted_text
+    type: text
+    configuration:
+      bundles:
+        asu_repository_item: asu_repository_item
+        article: 0
+        collection: 0
+        page: 0
+        scholarly_work: 0
   etdf_created_year_only:
     label: 'Date Created'
     property_path: etdf_created_year_only
@@ -493,6 +547,11 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_temporal_subject
+  field_title:
+    label: 'Component All Titles'
+    datasource_id: 'entity:node'
+    property_path: 'search_api_reverse_entity_references_node__field_member_of:field_title'
+    type: text
   field_title_subject:
     label: 'Title Subject'
     datasource_id: 'entity:node'
@@ -567,10 +626,10 @@ field_settings:
       view_mode:
         'entity:node':
           article: ''
-          asu_repository_item: full_metadata
+          asu_repository_item: ''
           collection: ''
-          islandora_object: ''
           page: ''
+          scholarly_work: ''
   resource_type_name:
     label: 'Resource Type'
     datasource_id: 'entity:node'
@@ -643,6 +702,8 @@ processor_settings:
     weights:
       preprocess_index: 5
   complex_title: {  }
+  custom_value: {  }
+  descendant_extracted_text: {  }
   entity_type: {  }
   etdf_created_year_only: {  }
   hierarchy:

--- a/config/sync/views.view.solr_search_content.yml
+++ b/config/sync/views.view.solr_search_content.yml
@@ -1465,6 +1465,44 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
+        complex_object_child:
+          id: complex_object_child
+          table: search_api_index_default_solr_index
+          field: complex_object_child
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_boolean
+          operator: '='
+          value: '0'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups: {  }
@@ -1750,15 +1788,15 @@ display:
           parse_mode: terms
           min_length: null
           fields: {  }
-        status:
-          id: status
+        complex_object_child:
+          id: complex_object_child
           table: search_api_index_default_solr_index
-          field: status
+          field: complex_object_child
           relationship: none
           group_type: group
           admin_label: ''
           plugin_id: search_api_boolean
-          operator: '='
+          operator: '!='
           value: '1'
           group: 1
           exposed: false
@@ -1895,7 +1933,8 @@ display:
             offset_label: Offset
           quantity: 7
       cache:
-        type: none
+        type: search_api_tag
+        options: {  }
       sorts:
         search_api_relevance:
           id: search_api_relevance
@@ -2125,7 +2164,7 @@ display:
       display_extenders: {  }
       path: items/%node/search
     cache_metadata:
-      max-age: -1
+      max-age: 0
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
@@ -2134,6 +2173,19 @@ display:
         - 'url.query_args:sort_by'
         - 'user.node_grants:view'
       tags:
+        - 'config:facets.facet.all_subjects_cpx'
+        - 'config:facets.facet.authors_agent_by_role_cpx_'
+        - 'config:facets.facet.creators_and_contributors_cpx'
+        - 'config:facets.facet.creators_cpx'
+        - 'config:facets.facet.date_created_cpx'
+        - 'config:facets.facet.genre_cpx'
+        - 'config:facets.facet.language_cpx'
+        - 'config:facets.facet.open_access_cpx'
+        - 'config:facets.facet.peer_reviewed_cpx'
+        - 'config:facets.facet.place_of_publication_cpx'
+        - 'config:facets.facet.resource_type_cpx'
+        - 'config:facets.facet.status_cpx'
+        - 'config:facets.facet.thesis_advisors_agent_by_role_cpx'
         - 'config:field.storage.node.field_edtf_date_created'
         - 'config:field.storage.node.field_linked_agent'
         - 'config:field.storage.node.field_model'

--- a/web/modules/custom/asu_search/asu_search.module
+++ b/web/modules/custom/asu_search/asu_search.module
@@ -1,19 +1,25 @@
 <?php
 
-use Drupal\search_api\IndexInterface;
-use Drupal\views\ViewExecutable;
-use Drupal\views\Plugin\views\cache\CachePluginBase;
-use Drupal\user\Entity\User;
-use Drupal\taxonomy\Entity\Term;
+/**
+ * @file
+ */
+
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
+use Drupal\search_api\Entity\Index;
+use Drupal\search_api\IndexInterface;
+use Drupal\taxonomy\Entity\Term;
+use Drupal\user\Entity\User;
+use Drupal\views\ViewExecutable;
 
 /**
  * Implements hook_form_alter().
+ *
  * @param $form
- * @param FormStateInterface $form_state
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
  * @param $form_id
  */
-function asu_search_form_views_exposed_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id){
+function asu_search_form_views_exposed_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   $current_path = \Drupal::service('path.current')->getPath();
   $node = \Drupal::routeMatch()->getParameter('node');
   if (!is_object($node) && $node) {
@@ -62,6 +68,9 @@ function asu_search_search_api_solr_field_mapping_alter(IndexInterface $index, a
   $fields['asu_identifier'] = 'sm_asu_identifier';
 }
 
+/**
+ * Implements hook_preprocess_node().
+ */
 function asu_search_preprocess_node(&$variables) {
   if ($variables['node'] && $variables['node']->getType() == 'asu_repository_item') {
     $asu_utils = \Drupal::service('asu_utils');
@@ -73,25 +82,6 @@ function asu_search_preprocess_node(&$variables) {
         $variables['changed_ago'] =
           $date_formatter->formatTimeDiffSince($variables['node']->getChangedTime(), ['granularity' => 2, 'return_as_object' => TRUE])->toRenderable();
       }
-      // if ($variables['node']->get('field_model') != NULL && count($variables['node']->get('field_model')) > 0) {
-      //   $model = $variables['node']->get('field_model')->referencedEntities()[0]->getName();
-      //   if ($model == "Complex Object") {
-      //     $complex_obj_child = \Drupal::entityTypeManager()->getStorage('node')->loadByProperties(['field_member_of' => $variables['node']->id()]);
-      //     $utils = \Drupal::service('islandora.utils');
-      //     // loop through the children
-      //     foreach ($complex_obj_child as $child) {
-      //       // for each child, get the thumbnail media
-      //       // if no thumbnail media continue
-      //       // if found, return and set that thumbnail as a variable
-      //       $thumbn_term = $utils->getTermForUri('http://pcdm.org/use#ThumbnailImage');
-      //       $thumb_media = $utils->getMediaWithTerm($child, $thumbn_term);
-      //       if ($thumb_media) {
-      //         $variables['complex_obj_thumb'] = $thumb_media->get('field_media_image')->entity->createFileUrl();
-      //         break;
-      //       }
-      //     }
-      //   }
-      // }
     }
     if ($variables['view_mode'] == 'asu_complex_object') {
       $childs = \Drupal::entityTypeManager()->getStorage('node')->loadByProperties(['field_member_of' => $variables['node']->id()]);
@@ -116,7 +106,7 @@ function asu_search_preprocess_views_view(&$variables) {
       $view->execute($view->current_display);
       $variables['total_rows_formatted'] = number_format($view->total_rows);
 
-      // inspect the query from the URL and if there are any facets, suppress
+      // Inspect the query from the URL and if there are any facets, suppress
       // the inclusion of the collections block at the top of the /search page.
       $facet_filters = \Drupal::request()->query->all()['f'];
       if (is_array($facet_filters) && count($facet_filters) > 0) {
@@ -152,13 +142,18 @@ function asu_search_preprocess_views_view(&$variables) {
   }
 }
 
+/**
+ * Implements hook_views_pre_render().
+ *
+ * Adds metadata download links for relevant users.
+ */
 function asu_search_views_pre_render(ViewExecutable $view) {
   if ($view->id() == 'solr_search_content' && ($view->current_display === 'page_1' || $view->current_display === 'page_4')) {
     $results = $view->result;
     $ids = [];
     $user = User::load(\Drupal::currentUser()->id());
     $user_roles = $user->getRoles();
-    if (in_array("administrator", $user_roles) || in_array("metadata_manager", $user_roles)){
+    if (in_array("administrator", $user_roles) || in_array("metadata_manager", $user_roles)) {
       foreach ($results as $r) {
         $ids[] = $r->_object->getEntity()->id();
       }
@@ -172,10 +167,11 @@ function asu_search_views_pre_render(ViewExecutable $view) {
         $query_string_parts = [];
         foreach ($query_parts as $query_key => $query_value) {
           if (is_array($query_value)) {
-          foreach ($query_value as $key_key => $query_value_value) {
-            $query_string_parts[] = $query_key . '[' . $key_key . ']=' . $query_value_value;
+            foreach ($query_value as $key_key => $query_value_value) {
+              $query_string_parts[] = $query_key . '[' . $key_key . ']=' . $query_value_value;
+            }
           }
-          } else {
+          else {
             $query_string_parts[] = $query_key . '=' . $query_value;
           }
         }
@@ -191,5 +187,36 @@ function asu_search_views_pre_render(ViewExecutable $view) {
       }
     }
   }
-  // TODO: may need to handle the complex object search page separately here.
+  // @todo may need to handle the complex object search page separately here.
+}
+
+/**
+ * Implements hook_media_presave().
+ *
+ * Marks ancestor items of extracted text media for reindexing
+ * when the extracted text field updates.
+ */
+function asu_search_media_presave($media) {
+  if ($media->bundle() == 'extracted_text' & $media->hasField('field_edited_text') & !$media->get('field_edited_text')->isEmpty()) {
+    if (!$media->get('field_edited_text')->equals($media->original->get('field_edited_text'))) {
+      $iu = \Drupal::service('islandora.utils');
+      $n = $iu->getParentNode($media);
+      if (!$n) {
+        return;
+      }
+      $to_reindex = [];
+      // We don't need to reindex the parent, because the
+      // islandora_text_extraction module does that for us,
+      // but we still need to mark it's ancestors.
+      foreach (Drupal::entityTypeManager()->getStorage('node')->loadMultiple($iu->findAncestors($n)) as $node) {
+        if ($node->bundle() != 'asu_repository_item') {
+          continue;
+        }
+        foreach ($node->getTranslationLanguages() as $language) {
+          $to_reindex[] = "{$node->id()}:{$language->getId()}";
+        }
+      }
+      Index::load('default_solr_index')->trackItemsUpdated('entity:node', $to_reindex);
+    }
+  }
 }

--- a/web/modules/custom/asu_search/config/schema/asu_search.schema.yml
+++ b/web/modules/custom/asu_search/config/schema/asu_search.schema.yml
@@ -1,0 +1,7 @@
+field.formatter.settings.typed_relation_brief:
+  type: mapping
+  label: 'Typed Relation Brief settings'
+  mapping:
+    unlinked_without_uri:
+      type: boolean
+      label: 'Unlink Relations w/o a URI'

--- a/web/modules/custom/asu_search/config/schema/asu_search.schema.yml
+++ b/web/modules/custom/asu_search/config/schema/asu_search.schema.yml
@@ -1,7 +1,0 @@
-field.formatter.settings.typed_relation_brief:
-  type: mapping
-  label: 'Typed Relation Brief settings'
-  mapping:
-    unlinked_without_uri:
-      type: boolean
-      label: 'Unlink Relations w/o a URI'

--- a/web/modules/custom/asu_search/src/Plugin/Field/FieldFormatter/TypedRelationBriefFormatter.php
+++ b/web/modules/custom/asu_search/src/Plugin/Field/FieldFormatter/TypedRelationBriefFormatter.php
@@ -2,8 +2,9 @@
 
 namespace Drupal\asu_search\Plugin\Field\FieldFormatter;
 
-use Drupal\Core\Field\Plugin\Field\FieldFormatter\EntityReferenceLabelFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\Plugin\Field\FieldFormatter\EntityReferenceLabelFormatter;
+use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Plugin implementation of the 'TypedRelationBriefFormatter'.
@@ -21,6 +22,30 @@ class TypedRelationBriefFormatter extends EntityReferenceLabelFormatter {
   /**
    * {@inheritdoc}
    */
+  public static function defaultSettings() {
+    return [
+      'unlink_without_uri' => FALSE,
+    ] + parent::defaultSettings();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    $form = parent::settingsForm($form, $form_state);
+
+    $form['unlink_without_uri'] = [
+      '#title' => $this->t('Unlink Relations without URIs'),
+      '#type' => 'checkbox',
+      '#default_value' => $this->getSetting('unlink_without_uri'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $elements = parent::viewElements($items, $langcode);
     $unique_tids = [];
@@ -29,7 +54,7 @@ class TypedRelationBriefFormatter extends EntityReferenceLabelFormatter {
       $this_tid = $item->target_id;
       $delta_to_update = in_array($this_tid, $unique_tids);
       $rel_types = $item->getRelTypes();
-      $rel_type = isset($rel_types[$item->rel_type]) ? $rel_types[$item->rel_type] : $item->rel_type;
+      $rel_type = $rel_types[$item->rel_type] ?? $item->rel_type;
       if (isset($elements[$delta])) {
         if (!$delta_to_update) {
           $unique_tids[$delta] = $this_tid;
@@ -43,7 +68,15 @@ class TypedRelationBriefFormatter extends EntityReferenceLabelFormatter {
           unset($elements[$delta]);
         }
       }
-      if (array_key_exists($delta, $elements) && array_key_exists('#title', $elements[$delta])) {
+      $target_term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->load($this_tid);
+      if ($this->getSetting('unlink_without_uri') && $target_term && $target_term->hasField('field_authority_link') && $target_term->get('field_authority_link')->isEmpty()) {
+        $label = '';
+        foreach (['#title', '#suffix'] as $label_part) {
+          $label .= ($elements[$delta][$label_part]) ? $elements[$delta][$label_part] : '';
+        }
+        $elements[$delta] = ['#plain_text' => $label];
+      }
+      elseif (array_key_exists($delta, $elements) && array_key_exists('#title', $elements[$delta])) {
         $url = \Drupal::service('facets.utility.url_generator')->getUrl(['linked_agents' => [$elements[$delta]['#title']]]);
         $elements[$delta]['#url'] = $url;
       }
@@ -52,7 +85,7 @@ class TypedRelationBriefFormatter extends EntityReferenceLabelFormatter {
   }
 
   /**
-   *
+   * Clean up Relator utility.
    */
   private function cleanUpRelator($rel_type) {
     $re = '/(.*) \(\S*/m';

--- a/web/modules/custom/asu_search/src/Plugin/Field/FieldFormatter/TypedRelationBriefFormatter.php
+++ b/web/modules/custom/asu_search/src/Plugin/Field/FieldFormatter/TypedRelationBriefFormatter.php
@@ -4,7 +4,6 @@ namespace Drupal\asu_search\Plugin\Field\FieldFormatter;
 
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\Plugin\Field\FieldFormatter\EntityReferenceLabelFormatter;
-use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Plugin implementation of the 'TypedRelationBriefFormatter'.
@@ -18,30 +17,6 @@ use Drupal\Core\Form\FormStateInterface;
  * )
  */
 class TypedRelationBriefFormatter extends EntityReferenceLabelFormatter {
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function defaultSettings() {
-    return [
-      'unlink_without_uri' => FALSE,
-    ] + parent::defaultSettings();
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function settingsForm(array $form, FormStateInterface $form_state) {
-    $form = parent::settingsForm($form, $form_state);
-
-    $form['unlink_without_uri'] = [
-      '#title' => $this->t('Unlink Relations without URIs'),
-      '#type' => 'checkbox',
-      '#default_value' => $this->getSetting('unlink_without_uri'),
-    ];
-
-    return $form;
-  }
 
   /**
    * {@inheritdoc}
@@ -68,15 +43,7 @@ class TypedRelationBriefFormatter extends EntityReferenceLabelFormatter {
           unset($elements[$delta]);
         }
       }
-      $target_term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->load($this_tid);
-      if ($this->getSetting('unlink_without_uri') && $target_term && $target_term->hasField('field_authority_link') && $target_term->get('field_authority_link')->isEmpty()) {
-        $label = '';
-        foreach (['#title', '#suffix'] as $label_part) {
-          $label .= ($elements[$delta][$label_part]) ? $elements[$delta][$label_part] : '';
-        }
-        $elements[$delta] = ['#plain_text' => $label];
-      }
-      elseif (array_key_exists($delta, $elements) && array_key_exists('#title', $elements[$delta])) {
+      if (array_key_exists($delta, $elements) && array_key_exists('#title', $elements[$delta])) {
         $url = \Drupal::service('facets.utility.url_generator')->getUrl(['linked_agents' => [$elements[$delta]['#title']]]);
         $elements[$delta]['#url'] = $url;
       }

--- a/web/modules/custom/asu_search/src/Plugin/search_api/processor/DescendantExtractedText.php
+++ b/web/modules/custom/asu_search/src/Plugin/search_api/processor/DescendantExtractedText.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Drupal\asu_search\Plugin\search_api\processor;
+
+use Drupal\islandora\IslandoraUtils;
+use Drupal\node\NodeInterface;
+use Drupal\search_api\Datasource\DatasourceInterface;
+use Drupal\search_api\Item\ItemInterface;
+use Drupal\search_api\LoggerTrait;
+use Drupal\search_api\Processor\ProcessorPluginBase;
+use Drupal\search_api\Processor\ProcessorProperty;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\asu_search\Plugin\search_api\processor\Property\NodeTypeProperty;
+
+/**
+ * Adds an additional field containing the child extracted text.
+ *
+ * @SearchApiProcessor(
+ *   id = "descendant_extracted_text",
+ *   label = @Translation("Descendant Extracted Text"),
+ *   description = @Translation("Adds an additional field containing the extracted text of descendant items."),
+ *   stages = {
+ *     "add_properties" = 0,
+ *   },
+ *   locked = true,
+ *   hidden = true,
+ * )
+ */
+class DescendantExtractedText extends ProcessorPluginBase {
+
+  use LoggerTrait;
+
+  /**
+   * Islandora Utils for working with Media.
+   *
+   * @var \Drupal\islandora\IslandoraUtils
+   */
+  protected $islandoraUtils;
+
+  /**
+   * The node storage.
+   *
+   * @var \Drupal\node\NodeStorageInterface
+   */
+  protected $nodeStorage;
+
+  /**
+   * The term for extracted text media use.
+   *
+   * @var \Drupal\taxomony\TermInterface
+   */
+  protected $extractedTextTerm;
+
+  const EDITED_TEXT_PROPERTY = 'field_edited_text';
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    /** @var static $plugin */
+    $plugin = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+
+    $plugin->setLogger($container->get('logger.channel.search_api'));
+    $plugin->islandoraUtils = $container->get('islandora.utils');
+    $plugin->nodeStorage = $container->get('entity_type.manager')->getStorage('node');
+    $plugin->extractedTextTerm = $plugin->islandoraUtils->getTermForUri('http://pcdm.org/use#ExtractedText');
+
+    return $plugin;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPropertyDefinitions(DatasourceInterface $datasource = NULL) {
+    $properties = [];
+
+    if (!$datasource) {
+      $definition = [
+        'label' => $this->t('Descendant Extracted Text'),
+        'description' => $this->t('The extracted text of descendant items.'),
+        'type' => 'search_api_text',
+        'processor_id' => $this->getPluginId(),
+      ];
+      $properties['descendant_extracted_text'] = new NodeTypeProperty($definition);
+    }
+
+    return $properties;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function addFieldValues(ItemInterface $item) {
+    $node = $item->getOriginalObject()->getValue();
+    if (!$node instanceof NodeInterface) {
+      $this->getLogger()->warning("Item isn't a node: " . get_class($node));
+      return;
+    }
+    $fields = $this->getFieldsHelper()
+      ->filterForPropertyPath($item->getFields(), NULL, 'descendant_extracted_text');
+    foreach ($fields as $field) {
+      $config = $field->getConfiguration();
+      $results = array_filter($this->gatherDescendantExtractedText($node, $config['bundles']));
+      foreach ($results as $result) {
+        $field->addValue($result);
+      }
+    }
+  }
+
+  /**
+   * Recurses descendants to pull extracted text.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   Node to check for descendants with extracted text.
+   *
+   * @return array
+   *   Array of extracted text values.
+   */
+  protected function gatherDescendantExtractedText(NodeInterface $node, array $bundles) {
+    $results = [];
+
+    // Skip bundles not in config, if set.
+    if (!empty($bundles) && !in_array($node->bundle(), $bundles)) {
+      return $results;
+    }
+
+    // Get text from the current item.
+    $extractedTextMedia = $this->islandoraUtils->getMediaWithTerm($node, $this->extractedTextTerm);
+    if ($extractedTextMedia) {
+      $extracted = '';
+      foreach ($extractedTextMedia->get(self::EDITED_TEXT_PROPERTY) as $value) {
+        $extracted .= ($value->value) ? $value->value : '';
+      }
+      $results[] = $extracted;
+    }
+    // Grab text from children.
+    foreach ($this->nodeStorage->loadByProperties([IslandoraUtils::MEMBER_OF_FIELD => $node->id()]) as $child) {
+      $results += $this->gatherDescendantExtractedText($child, $bundles);
+    }
+    return $results;
+  }
+
+}

--- a/web/modules/custom/asu_search/src/Plugin/search_api/processor/Property/NodeTypeProperty.php
+++ b/web/modules/custom/asu_search/src/Plugin/search_api/processor/Property/NodeTypeProperty.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Drupal\asu_search\Plugin\search_api\processor\Property;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\search_api\Item\FieldInterface;
+use Drupal\search_api\Processor\ConfigurablePropertyBase;
+
+/**
+ * Defines a "node type" property.
+ *
+ * @see \Drupal\as_search_\Plugin\search_api\processor\DescendantExtractedText
+ */
+class NodeTypeProperty extends ConfigurablePropertyBase {
+
+  use StringTranslationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return [
+      'bundles' => [],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(FieldInterface $field, array $form, FormStateInterface $form_state) {
+    $configuration = $field->getConfiguration();
+
+    // Build an option list of available node bundles.
+    $options = [];
+    foreach (\Drupal::service('entity_type.bundle.info')->getBundleInfo('node') as $bundle_id => $properties) {
+      $options[$bundle_id] = $properties['label'];
+    }
+
+    $form['bundles'] = [
+      '#title' => $this->t('Bundles'),
+      '#type' => 'checkboxes',
+      '#options' => $options,
+      '#default_value' => $configuration['bundles'] ?? [],
+    ];
+    return $form;
+  }
+
+}


### PR DESCRIPTION
In order to make the main search clearer, we are removing complex object children from the search and augmenting the parent records of those complex objects.

Note that this is a bit heavier on the Solr server during indexing, so the max memory should be increased in `/etc/default/solr.in.sh`.