### PR TITLE
Descendant extracted optimization

### DIFF
--- a/config/prism/search_api.index.default_solr_index.yml
+++ b/config/prism/search_api.index.default_solr_index.yml
@@ -219,6 +219,7 @@ field_settings:
         article: 0
         collection: 0
         page: 0
+      media_use_term: '18'
   document_uri:
     label: 'Document URI'
     datasource_id: 'entity:node'

--- a/config/sync/search_api.index.default_solr_index.yml
+++ b/config/sync/search_api.index.default_solr_index.yml
@@ -221,7 +221,7 @@ field_settings:
         article: 0
         collection: 0
         page: 0
-        scholarly_work: 0
+      media_use_term: '17'
   etdf_created_year_only:
     label: 'Date Created'
     property_path: etdf_created_year_only

--- a/web/modules/custom/asu_search/src/Plugin/search_api/processor/Property/DescendantExtractedTextProperty.php
+++ b/web/modules/custom/asu_search/src/Plugin/search_api/processor/Property/DescendantExtractedTextProperty.php
@@ -8,11 +8,11 @@ use Drupal\search_api\Item\FieldInterface;
 use Drupal\search_api\Processor\ConfigurablePropertyBase;
 
 /**
- * Defines a "node type" property.
+ * Defines a "descendant extracted text" property.
  *
  * @see \Drupal\as_search_\Plugin\search_api\processor\DescendantExtractedText
  */
-class NodeTypeProperty extends ConfigurablePropertyBase {
+class DescendantExtractedTextProperty extends ConfigurablePropertyBase {
 
   use StringTranslationTrait;
 
@@ -21,7 +21,8 @@ class NodeTypeProperty extends ConfigurablePropertyBase {
    */
   public function defaultConfiguration() {
     return [
-      'bundles' => [],
+	    'bundles' => [],
+	    'media_use_term' => 0,
     ];
   }
 
@@ -43,6 +44,15 @@ class NodeTypeProperty extends ConfigurablePropertyBase {
       '#options' => $options,
       '#default_value' => $configuration['bundles'] ?? [],
     ];
+
+    $form['media_use_term'] = [
+      '#title' => $this->t('Extracted Text Term'),
+      '#description' => $this->t('Select the Media Use term of the media for the extracted text. (Usually "Extracted Text".)'),
+      '#type' => 'entity_autocomplete',
+      '#target_type' => 'taxonomy_term',
+      '#selection_settings' => ['target_bundles' => ['islandora_media_use']],
+     ];
+
     return $form;
   }
 


### PR DESCRIPTION
The descendant extracted text search index processor used the Islandora Utils lookup for the Extracted Text URI. This was causing _many very slow_  database queries (scanning three very large tables for the same string).

This PR moves this lookup into a one-time lookup during configuration; essentially eliminating this query in the logs.